### PR TITLE
Handle minor differences when comparing routes

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Link from "next/link";
 
 type Lang = "ru" | "bg" | "en" | "ua";
 
@@ -38,9 +39,9 @@ export default function Header({ lang = "ru", onLangChange }: HeaderProps) {
     <header className="bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70 sticky top-0 z-30 border-b border-slate-200">
       <nav className="container mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
         {/* Лого */}
-        <a href="/" className="font-bold text-primary text-lg md:text-2xl tracking-tight">
+        <Link href="/" className="font-bold text-primary text-lg md:text-2xl tracking-tight">
           Максимов Турc
-        </a>
+        </Link>
 
         {/* Меню */}
         <ul className="hidden md:flex gap-6 items-center">

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -1,7 +1,7 @@
 // src/components/routes/Routes.tsx
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { MapPin } from "lucide-react";
 import { API } from "@/config";
 
@@ -96,8 +96,8 @@ const deepEqualStops = (a: Stop[] = [], b: Stop[] = []) => {
       sa.name?.trim() !== sb.name?.trim() ||
       (sa.arrival_time || "") !== (sb.arrival_time || "") ||
       (sa.departure_time || "") !== (sb.departure_time || "") ||
-      (sa.description || "") !== (sb.description || "") ||
-      (sa.location || "") !== (sb.location || "")
+      (sa.description?.trim() || "") !== (sb.description?.trim() || "") ||
+      (sa.location?.trim() || "") !== (sb.location?.trim() || "")
     ) {
       return false;
     }


### PR DESCRIPTION
## Summary
- Trim stop description and location when comparing routes to detect duplicates
- Replace root anchor with Next.js `Link` to satisfy linting

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a31f55d8d883278432b1fcb227cae2