### PR TITLE
Fix search criteria names for search button

### DIFF
--- a/src/components/hero/HeroSection.tsx
+++ b/src/components/hero/HeroSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import SearchForm from './SearchForm';
 
 type Lang = 'ru' | 'bg' | 'en' | 'ua';
@@ -8,7 +8,13 @@ type Lang = 'ru' | 'bg' | 'en' | 'ua';
 type Props = {
   lang?: Lang;
   className?: string;
-  onSearch: (criteria: { from: string; to: string; date: string; seatCount: number }) => void;
+  onSearch: (criteria: {
+    from: string;
+    to: string;
+    date: string;
+    seatCount: number;
+    returnDate?: string;
+  }) => void;
 };
 
 const TXT = {
@@ -33,12 +39,6 @@ const TXT = {
 export default function HeroSection({ lang = 'ru', className = '', onSearch }: Props) {
   const t = TXT[lang] ?? TXT.ru;
 
-  // локально управляемые поля формы
-  const [from, setFrom] = useState('');
-  const [to, setTo] = useState('');
-  const [date, setDate] = useState('');           // YYYY-MM-DD
-  const [seatCount, setSeatCount] = useState(1);
-
   return (
     <section
       className={`relative min-h-[420px] flex flex-col items-center justify-center
@@ -58,14 +58,6 @@ export default function HeroSection({ lang = 'ru', className = '', onSearch }: P
         {/* Форма поиска */}
         <div className="w-full max-w-5xl">
           <SearchForm
-            from={from}
-            to={to}
-            date={date}
-            seatCount={seatCount}
-            setFrom={setFrom}
-            setTo={setTo}
-            setDate={setDate}
-            setSeatCount={setSeatCount}
             lang={lang}
             onSearch={(criteria) => {
               // отдаём наружу чистые данные

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -18,8 +18,8 @@ type Props = {
   initialReturnDate?: string; // YYYY-MM-DD
   initialSeats?: number;
   onSearch: (params: {
-    fromId: number;
-    toId: number;
+    from: string;
+    to: string;
     date: string;
     returnDate?: string;
     seatCount: number;
@@ -189,8 +189,8 @@ export default function SearchForm({
     e.preventDefault();
     if (!fromId || !toId || !departDate) return;
     onSearch({
-      fromId,
-      toId,
+      from: String(fromId),
+      to: String(toId),
       date: departDate,
       returnDate: returnDate || undefined,
       seatCount,


### PR DESCRIPTION
## Summary
- Forward `from`/`to` fields from SearchForm instead of numeric IDs
- Simplify HeroSection to delegate state to SearchForm

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a41b2761408327bf5a232019da7360