### PR TITLE
feat: add booking card skeleton

### DIFF
--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -1,0 +1,10 @@
+import BookingCard from "@/components/booking/BookingCard";
+
+export default function BookingPage() {
+  return (
+    <main className="min-h-screen p-4">
+      <BookingCard />
+    </main>
+  );
+}
+

--- a/src/components/booking/BookingCard.tsx
+++ b/src/components/booking/BookingCard.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React, { useState } from "react";
+
+const steps = ["Поиск", "Рейсы", "Места", "Пассажиры"] as const;
+
+export default function BookingCard() {
+  const [current, setCurrent] = useState(0);
+
+  const renderStep = (index: number) => {
+    switch (index) {
+      case 0:
+        return <div>Поиск: форма поиска</div>;
+      case 1:
+        return <div>Рейсы: список рейсов</div>;
+      case 2:
+        return <div>Места: схема мест</div>;
+      case 3:
+        return <div>Пассажиры и оплата: форма</div>;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-4 md:flex-row">
+      <div className="flex-1 space-y-4">
+        <Stepper current={current} onSelect={setCurrent} />
+
+        {/* Steps as accordion */}
+        {steps.map((step, index) => (
+          <details
+            key={step}
+            open={index === current}
+            className="rounded-md border"
+          >
+            <summary
+              className="cursor-pointer p-4 font-medium"
+              onClick={() => setCurrent(index)}
+            >
+              {step}
+            </summary>
+            {index === current && (
+              <div className="p-4">{renderStep(index)}</div>
+            )}
+          </details>
+        ))}
+      </div>
+
+      <Summary current={current} />
+    </div>
+  );
+}
+
+function Stepper({
+  current,
+  onSelect,
+}: {
+  current: number;
+  onSelect: (i: number) => void;
+}) {
+  return (
+    <nav className="flex items-center justify-between text-sm">
+      {steps.map((label, index) => {
+        const status =
+          index < current ? "done" : index === current ? "active" : "todo";
+        return (
+          <button
+            key={label}
+            onClick={() => index <= current && onSelect(index)}
+            className={
+              status === "active"
+                ? "text-blue-600"
+                : status === "done"
+                ? "text-green-600"
+                : "text-gray-400"
+            }
+          >
+            {status === "done" && "✓ "}
+            {label}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+function Summary({ current }: { current: number }) {
+  const cta = current === steps.length - 1 ? "Оплатить" : "Далее";
+  return (
+    <aside className="fixed bottom-0 left-0 right-0 border bg-white p-4 md:sticky md:top-4 md:w-64 md:self-start md:rounded-md">
+      <h4 className="mb-2 font-semibold">Итоги</h4>
+      <div className="space-y-1 text-sm">
+        <p>Маршрут + дата</p>
+        <p>Пассажиры: -</p>
+        <p>Места: -</p>
+        <p>Сумма: -</p>
+      </div>
+      <button className="mt-4 w-full border p-2">{cta}</button>
+    </aside>
+  );
+}
+


### PR DESCRIPTION
## Summary
- scaffold booking card with stepper-based flow and placeholder steps
- add sticky summary panel for route, seats, passengers and total
- expose new booking page using the booking card skeleton

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a469cf16b48327a667cbb0aa93a857