### PR TITLE
refactor TripList styles to Tailwind classes

### DIFF
--- a/src/components/search/TripList.module.css
+++ b/src/components/search/TripList.module.css
@@ -1,0 +1,3 @@
+.item {
+  @apply flex items-center gap-2 mb-2;
+}

--- a/src/components/search/TripList.tsx
+++ b/src/components/search/TripList.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { Tour } from "./SearchResults";
+import styles from "./TripList.module.css";
 
 type TripListProps = {
   title: string;
@@ -24,19 +25,11 @@ export default function TripList({
 }: TripListProps) {
   return (
     <>
-      <h3 style={{ marginTop: 12, marginBottom: 8 }}>{title}:</h3>
+      <h3 className="mt-3 mb-2">{title}:</h3>
       {tours.map((tour) => {
         const isChosen = selectedId === tour.id;
         return (
-          <div
-            key={tour.id}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-              marginBottom: 8,
-            }}
-          >
+          <div key={tour.id} className={styles.item}>
             <span>
               Рейс #{tour.id}, дата: {tour.date} —{" "}
               {t.freeSeats(freeSeatsValue(tour.seats))}


### PR DESCRIPTION
## Summary
- replace inline styles in TripList with Tailwind classes
- extract shared trip list item styles into a CSS module

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a471a7dee483278957cc7577fdc6f3