### PR TITLE
fix: reference Tailwind in TripList module

### DIFF
--- a/src/components/search/TripList.module.css
+++ b/src/components/search/TripList.module.css
@@ -1,3 +1,5 @@
+@reference "../../app/globals.css";
+
 .item {
   @apply flex items-center gap-2 mb-2;
 }


### PR DESCRIPTION
## Summary
- reference global Tailwind CSS from `TripList.module.css` so `@apply` utilities resolve

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a476e212d08327ac767b4b98e035f2