### PR TITLE
feat: improve booking layout and trip selection

### DIFF
--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -2,7 +2,7 @@ import BookingCard from "@/components/booking/BookingCard";
 
 export default function BookingPage() {
   return (
-    <main className="min-h-screen p-4">
+    <main className="min-h-screen p-4 bg-sky-100">
       <BookingCard />
     </main>
   );

--- a/src/components/booking/BookingCard.tsx
+++ b/src/components/booking/BookingCard.tsx
@@ -17,10 +17,10 @@ export default function BookingCard() {
   const lang = "ru" as const;
 
   return (
-    <div className="mx-auto w-full max-w-5xl rounded-2xl border bg-white p-4 shadow">
+    <div className="mx-auto w-full max-w-5xl space-y-6">
       <SearchForm lang={lang} onSearch={(params) => setCriteria(params)} />
       {criteria && (
-        <div className="mt-6">
+        <div className="rounded-3xl bg-white/20 backdrop-blur p-5 shadow-lg ring-1 ring-white/30">
           <SearchResults lang={lang} {...criteria} />
         </div>
       )}

--- a/src/components/search/TripList.module.css
+++ b/src/components/search/TripList.module.css
@@ -3,3 +3,15 @@
 .item {
   @apply flex items-center gap-2 mb-2;
 }
+
+.btn {
+  @apply px-3 py-1 rounded-lg text-white transition-colors;
+}
+
+.pick {
+  @apply bg-sky-600 hover:bg-sky-700;
+}
+
+.chosen {
+  @apply bg-green-600 hover:bg-green-700;
+}

--- a/src/components/search/TripList.tsx
+++ b/src/components/search/TripList.tsx
@@ -34,7 +34,10 @@ export default function TripList({
               Рейс #{tour.id}, дата: {tour.date} —{" "}
               {t.freeSeats(freeSeatsValue(tour.seats))}
             </span>
-            <button onClick={() => onSelect(tour)}>
+            <button
+              onClick={() => onSelect(tour)}
+              className={`${styles.btn} ${isChosen ? styles.chosen : styles.pick}`}
+            >
               {isChosen ? t.chosen : t.pick}
             </button>
           </div>


### PR DESCRIPTION
## Summary
- keep ticket purchase flow on blue backdrop
- add styling for trip selection buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a47b2f27d08327b558e6b7df177e1e