### PR TITLE
fix: show calendar popover

### DIFF
--- a/src/components/hero/DateInput.tsx
+++ b/src/components/hero/DateInput.tsx
@@ -72,7 +72,7 @@ export default function DateInput({
       {open && !disabled && (
         <div
           ref={pop}
-          className="absolute z-50 mt-2"
+          className="absolute z-[100] mt-2"
           style={{ minWidth: 320 }}
         >
           <div className="rounded-2xl bg-white shadow-xl ring-1 ring-black/10">

--- a/src/components/hero/HeroSection.tsx
+++ b/src/components/hero/HeroSection.tsx
@@ -32,7 +32,7 @@ export default function HeroSection({ lang = 'ru' }: { lang?: Lang }) {
         </p>
 
         {/* ЕДИНАЯ КАПСУЛА: форма + (скрываемый) блок результатов */}
-        <div className="mx-auto mt-8 max-w-5xl rounded-3xl bg-white/20 backdrop-blur shadow-lg ring-1 ring-white/30 overflow-hidden">
+        <div className="mx-auto mt-8 max-w-5xl rounded-3xl bg-white/20 backdrop-blur shadow-lg ring-1 ring-white/30 overflow-visible relative">
 
           {/* ВСТАВЛЯЕМ ФОРМУ БЕЗ ЕЕ СОБСТВЕННОГО ВНЕШНЕГО КОНТЕЙНЕРА  */}
           <div className="p-5">


### PR DESCRIPTION
## Summary
- allow hero capsule content to overflow so date picker can escape
- raise z-index of calendar popover

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5acdcf4648327b673c420c3fdafd4