### PR TITLE
feat: send lang in search requests

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import HeroSection from "@/components/hero/HeroSection";
 import Routes from "@/components/Routes";
@@ -10,7 +10,14 @@ import About from "@/components/About";
 type Lang = "ru" | "bg" | "en" | "ua";
 
 export default function Page() {
-  const [lang] = useState<Lang>("ru");
+  const [lang, setLang] = useState<Lang>("ru");
+
+  useEffect(() => {
+    const nav = navigator.language.slice(0, 2) as Lang;
+    if (["ru", "bg", "en", "ua"].includes(nav)) {
+      setLang(nav);
+    }
+  }, []);
 
   return (
     <main className="min-h-screen">

--- a/src/components/hero/DirectionSelect.tsx
+++ b/src/components/hero/DirectionSelect.tsx
@@ -70,9 +70,12 @@ export default function DirectionSelect({
     async function load() {
       setDepLoading(true);
       try {
-        const url = new URL(`${API}/search/departures`);
-        url.searchParams.set('seats', String(seatCount || 1));
-        const res = await fetch(url.toString(), { cache: 'no-store' });
+        const res = await fetch(`${API}/search/departures`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ seats: seatCount || 1, lang }),
+          cache: 'no-store',
+        });
         if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
         const data: Stop[] = await res.json();
         if (!aborted) {
@@ -96,7 +99,7 @@ export default function DirectionSelect({
     return () => {
       aborted = true;
     };
-  }, [seatCount]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [seatCount, lang]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Загрузка конечных при выборе отправной
   useEffect(() => {
@@ -109,10 +112,16 @@ export default function DirectionSelect({
       }
       setArrLoading(true);
       try {
-        const url = new URL(`${API}/search/arrivals`);
-        url.searchParams.set('departure_stop_id', String(from));
-        url.searchParams.set('seats', String(seatCount || 1));
-        const res = await fetch(url.toString(), { cache: 'no-store' });
+        const res = await fetch(`${API}/search/arrivals`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            departure_stop_id: Number(from),
+            seats: seatCount || 1,
+            lang,
+          }),
+          cache: 'no-store',
+        });
         if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
         const data: Stop[] = await res.json();
         if (!aborted) {
@@ -135,7 +144,7 @@ export default function DirectionSelect({
     return () => {
       aborted = true;
     };
-  }, [from, seatCount]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [from, seatCount, lang]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const canSwap = useMemo(
     () => Boolean(from && to),

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -72,11 +72,14 @@ export default function SearchForm({
 
   useEffect(() => {
     let cancelled = false;
-    axios.get<Stop[]>(`${API}/search/departures`, { params: { seats: seatCount } })
+    axios
+      .post<Stop[]>(`${API}/search/departures`, { seats: seatCount, lang })
       .then(res => !cancelled && setDepartureStops(res.data || []))
       .catch(() => !cancelled && setDepartureStops([]));
-    return () => { cancelled = true; };
-  }, [seatCount]);
+    return () => {
+      cancelled = true;
+    };
+  }, [seatCount, lang]);
 
   useEffect(() => {
     let cancelled = false;
@@ -86,11 +89,16 @@ export default function SearchForm({
       setDepartDate('');   setReturnDate('');
       return;
     }
-    axios.get<Stop[]>(`${API}/search/arrivals`, { params: { departure_stop_id: fromId, seats: seatCount } })
+    axios
+      .post<Stop[]>(`${API}/search/arrivals`, {
+        departure_stop_id: fromId,
+        seats: seatCount,
+        lang,
+      })
       .then(res => !cancelled && setArrivalStops(res.data || []))
       .catch(() => !cancelled && setArrivalStops([]));
     return () => { cancelled = true; };
-  }, [fromId, seatCount]);
+  }, [fromId, seatCount, lang]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Summary
- detect browser language and store in state
- send lang in POST requests for departures and arrivals
- support lang-based reloads in direction selector

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a5c1e9e28883279e6c2835b1011bab