### PR TITLE
Align search form controls with unified pill layout

### DIFF
--- a/src/components/hero/DateInput.tsx
+++ b/src/components/hero/DateInput.tsx
@@ -1,136 +1,70 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { Calendar as CalendarIcon } from "lucide-react";
-import Calendar from "../Calendar"; // ваш компонент
+import React from "react";
 
 type Props = {
   value: string;
   setValue: (v: string) => void;
   activeDates?: string[];
-  minDate?: string;
   disabled?: boolean;
-  className?: string; // «пилюля» по умолчанию
+  className?: string;
+  label?: string;                 // 🔹 подпись внутри пилюли: "Date" / "Return"
   lang?: "ru" | "bg" | "en" | "ua";
+  onOpen?: () => void;            // если календарь внешне открывается
 };
-
-function toHuman(iso: string) {
-  if (!iso) return "";
-  const [y, m, d] = iso.split("-");
-  return y && m && d ? `${d}.${m}.${y}` : iso;
-}
 
 export default function DateInput({
   value,
-  setValue,
-  activeDates = [],
-  minDate,
+  setValue, // eslint-disable-line @typescript-eslint/no-unused-vars
+  activeDates = [], // eslint-disable-line @typescript-eslint/no-unused-vars
   disabled,
-  className = "h-12 px-4 rounded-2xl bg-white/90 hover:bg-white text-slate-800 shadow ring-1 ring-black/5 flex items-center gap-2",
+  className = "",
+  label,
   lang = "ru",
+  onOpen,
 }: Props) {
-  const [open, setOpen] = useState(false);
-  const anchorRef = useRef<HTMLDivElement>(null);
-  const popRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState({ top: 0, left: 0, width: 280 });
-
-  useEffect(() => {
-    if (!open || !anchorRef.current) return;
-    const r = anchorRef.current.getBoundingClientRect();
-    setPos({
-      top: r.bottom + window.scrollY + 6,
-      left: r.left + window.scrollX,
-      width: r.width,
-    });
-  }, [open]);
-
-  // пересчитать при скролле/resize
-  useEffect(() => {
-    if (!open) return;
-    const on = () => {
-      if (!anchorRef.current) return;
-      const r = anchorRef.current.getBoundingClientRect();
-      setPos({
-        top: r.bottom + window.scrollY + 6,
-        left: r.left + window.scrollX,
-        width: r.width,
-      });
-    };
-    window.addEventListener("scroll", on, true);
-    window.addEventListener("resize", on);
-    return () => {
-      window.removeEventListener("scroll", on, true);
-      window.removeEventListener("resize", on);
-    };
-  }, [open]);
-
-  // закрытие по Esc/клику вне
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
-    const onClick = (e: MouseEvent) => {
-      if (!popRef.current || !anchorRef.current) return;
-      if (
-        !popRef.current.contains(e.target as Node) &&
-        !anchorRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("keydown", onKey);
-    document.addEventListener("mousedown", onClick);
-    return () => {
-      document.removeEventListener("keydown", onKey);
-      document.removeEventListener("mousedown", onClick);
-    };
-  }, [open]);
-
-  const hasDate = Boolean(value);
+  // отображаемое значение (если пусто — покажем "— — —")
+  const human =
+    value
+      ? new Date(value + "T00:00:00Z").toLocaleDateString(
+          lang === "en" ? "en-GB" : lang,
+          { day: "2-digit", month: "2-digit", year: "numeric" }
+        )
+      : "— — —";
 
   return (
-    <div ref={anchorRef} className="relative">
-      {/* Пилюля (без плейсхолдера) */}
-      <button
-        type="button"
-        aria-label="Выбрать дату"
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        disabled={disabled}
-        className={className}
-        onClick={() => setOpen((v) => !v)}
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onOpen}
+      className={[
+        // единая «пилюля»: одинаковая высота/радиус/тени
+        "h-14 w-[200px] rounded-2xl bg-white/90 hover:bg-white shadow ring-1 ring-black/5",
+        "px-4 text-left",
+        "flex items-center",
+        className,
+        disabled ? "opacity-60 cursor-not-allowed" : "cursor-pointer",
+      ].join(" ")}
+    >
+      {/* левая иконка календаря */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="mr-3 h-5 w-5 text-slate-500 shrink-0"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
       >
-        <CalendarIcon className="h-5 w-5 opacity-80" />
-        <span className={hasDate ? "text-slate-900" : "text-transparent select-none"}>
-          {hasDate ? toHuman(value) : ".... .... ...."}
-        </span>
-      </button>
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+      </svg>
 
-      {/* Popover */}
-      {open && !disabled &&
-        createPortal(
-          <div
-            ref={popRef}
-            className="fixed z-[9999] shadow-xl rounded-2xl bg-white ring-1 ring-black/10"
-            style={{ top: pos.top, left: pos.left, minWidth: Math.max(320, pos.width) }}
-          >
-            <div className="px-3 pt-2 pb-1 text-xs text-slate-500">
-              Доступные даты отмечены точкой
-            </div>
-            <Calendar
-              activeDates={activeDates}
-              selectedDate={value}
-              minDate={minDate}
-              onSelect={(iso) => {
-                setValue(iso);
-                setOpen(false);
-              }}
-              lang={lang}
-              className="border-0 shadow-none"
-            />
-          </div>,
-          document.body
+      {/* текстовая часть: маленький лейбл + крупное значение в одну колонку */}
+      <span className="flex min-w-0 flex-col leading-tight">
+        {label && (
+          <span className="text-[11px] text-slate-500">{label}</span>
         )}
-    </div>
+        <span className="truncate text-slate-800">{human}</span>
+      </span>
+    </button>
   );
 }

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -4,6 +4,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 
+import Calendar from '../Calendar';
 import DateInput from './DateInput';
 import PassengersInput from './PassengersInput';
 import { API } from '@/config';
@@ -42,8 +43,6 @@ const L = {
   ua: { from: 'Звідки', to: 'Куди', date: 'Дата', back: 'Назад', search: 'Пошук', swapTitle: 'Поміняти місцями' },
 };
 
-const pill = 'h-12 rounded-2xl bg-white/90 hover:bg-white text-slate-800 shadow ring-1 ring-black/5 px-4';
-
 export default function SearchForm({
   lang = 'ru',
   initialFromId,
@@ -67,6 +66,9 @@ export default function SearchForm({
   const [arrivalStops, setArrivalStops] = useState<Stop[]>([]);
   const [departActive, setDepartActive] = useState<string[]>([]);
   const [returnActive, setReturnActive] = useState<string[]>([]);
+
+  const [showDepart, setShowDepart] = useState(false);
+  const [showReturn, setShowReturn] = useState(false);
 
   const fromId = useMemo(() => Number(from) || 0, [from]);
   const toId   = useMemo(() => Number(to)   || 0, [to]);
@@ -122,6 +124,9 @@ export default function SearchForm({
     setDepartDate(''); setReturnDate('');
   };
 
+  const handleDepartOpen = () => setShowDepart(true);
+  const handleReturnOpen = () => setShowReturn(true);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!fromId || !toId || !departDate) return;
@@ -138,66 +143,136 @@ export default function SearchForm({
   const row = (
     <div className="flex flex-wrap md:flex-nowrap items-center gap-3">
       <div className="relative flex w-full md:w-1/2">
-        <select aria-label={t.from} className={pill + ' w-1/2 pr-10 rounded-r-none'} value={from} onChange={e => setFrom(e.target.value)}>
+        <select
+          aria-label={t.from}
+          className="h-14 w-1/2 pr-10 rounded-2xl rounded-r-none bg-white/90 hover:bg-white text-slate-800 shadow ring-1 ring-black/5 px-4"
+          value={from}
+          onChange={(e) => setFrom(e.target.value)}
+        >
           <option value="">{t.from}</option>
-          {departureStops.map(s => <option key={s.id} value={s.id}>{s.stop_name}</option>)}
+          {departureStops.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.stop_name}
+            </option>
+          ))}
         </select>
-        <select aria-label={t.to} className={pill + ' w-1/2 pl-10 rounded-l-none'} value={to} onChange={e => setTo(e.target.value)} disabled={!fromId}>
+
+        <select
+          aria-label={t.to}
+          className="h-14 w-1/2 pl-10 rounded-2xl rounded-l-none bg-white/90 hover:bg-white text-slate-800 shadow ring-1 ring-black/5 px-4"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          disabled={!fromId}
+        >
           <option value="">{t.to}</option>
-          {arrivalStops.map(s => <option key={s.id} value={s.id}>{s.stop_name}</option>)}
+          {arrivalStops.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.stop_name}
+            </option>
+          ))}
         </select>
-        <button type="button" title={t.swapTitle} onClick={handleSwap}
-                className="absolute left-1/2 top-1/2 z-10 h-10 w-10 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/90 hover:bg-white text-sky-700 shadow ring-1 ring-black/5">⇄</button>
+
+        <button
+          type="button"
+          title={t.swapTitle}
+          onClick={handleSwap}
+          className="absolute left-1/2 top-1/2 z-10 h-10 w-10 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/90 hover:bg-white text-sky-700 shadow ring-1 ring-black/5 grid place-items-center"
+        >
+          ⇄
+        </button>
       </div>
 
-      <div className="flex w-full md:w-1/2 flex-wrap md:flex-nowrap items-center gap-3">
-        <div className="flex flex-col flex-1">
-          <span className="text-white/80 text-sm mb-1">{t.date}</span>
-          <DateInput
-            value={departDate}
-            setValue={setDepartDate}
-            activeDates={departActive}
-            lang={lang}
-            className={pill + ' flex items-center gap-2'}
-            disabled={!fromId || !toId}
-          />
-        </div>
-        <div className="flex flex-col flex-1">
-          <span className="text-white/80 text-sm mb-1">{t.back}</span>
-          <DateInput
-            value={returnDate}
-            setValue={setReturnDate}
-            activeDates={returnActive}
-            lang={lang}
-            className={pill + ' flex items-center gap-2'}
-            disabled={!fromId || !toId}
-          />
-        </div>
+      <div className="flex w-full md:w-1/2 items-center gap-3">
+        <DateInput
+          value={departDate}
+          setValue={setDepartDate}
+          activeDates={departActive}
+          label={t.date}
+          lang={lang}
+          disabled={!fromId || !toId}
+          onOpen={handleDepartOpen}
+        />
+
+        <DateInput
+          value={returnDate}
+          setValue={setReturnDate}
+          activeDates={returnActive}
+          label={t.back}
+          lang={lang}
+          disabled={!fromId || !toId}
+          onOpen={handleReturnOpen}
+        />
+
         <PassengersInput
           value={passengers}
           onChange={setPassengers}
-          className="flex items-center"
-          pillClass="h-12 px-3 rounded-2xl bg-white/90 hover:bg-white text-slate-800 shadow ring-1 ring-black/5 inline-flex items-center gap-2"
+          pillClass="h-14 px-3 rounded-2xl bg-white/90 hover:bg-white text-slate-800 shadow ring-1 ring-black/5 inline-flex items-center gap-2"
         />
-        <button type="submit"
-                className="h-12 px-6 rounded-2xl bg-[#ff6a00] hover:bg-[#ff7a1c] text-white font-medium shadow-lg"
-                disabled={!fromId || !toId || !departDate} aria-label={t.search}>{t.search}</button>
+
+        <button
+          type="submit"
+          className="h-14 px-6 rounded-2xl bg-[#ff6a00] hover:bg-[#ff7a1c] text-white font-medium shadow-lg"
+          disabled={!fromId || !toId || !departDate}
+          aria-label={t.search}
+        >
+          {t.search}
+        </button>
       </div>
     </div>
   );
 
-  // Обёртка: если embedded — возвращаем ТОЛЬКО строку
-  if (embedded) {
-    return <form onSubmit={handleSubmit} className="w-full">{row}</form>;
-  }
-
-  // Старый режим (самостоятельная капсула)
-  return (
+  const form = (
     <form onSubmit={handleSubmit} className="w-full">
-      <div className="mx-auto max-w-5xl rounded-3xl bg-white/20 backdrop-blur p-5 shadow-lg ring-1 ring-white/30">
-        {row}
-      </div>
+      {embedded ? (
+        row
+      ) : (
+        <div className="mx-auto max-w-5xl rounded-3xl bg-white/20 backdrop-blur p-5 shadow-lg ring-1 ring-white/30">
+          {row}
+        </div>
+      )}
     </form>
+  );
+
+  return (
+    <>
+      {form}
+      {showDepart && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/20"
+          onClick={() => setShowDepart(false)}
+        >
+          <div onClick={(e) => e.stopPropagation()}>
+            <Calendar
+              activeDates={departActive}
+              selectedDate={departDate}
+              onSelect={(iso) => {
+                setDepartDate(iso);
+                setShowDepart(false);
+              }}
+              lang={lang}
+            />
+          </div>
+        </div>
+      )}
+      {showReturn && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/20"
+          onClick={() => setShowReturn(false)}
+        >
+          <div onClick={(e) => e.stopPropagation()}>
+            <Calendar
+              activeDates={returnActive}
+              selectedDate={returnDate}
+              onSelect={(iso) => {
+                setReturnDate(iso);
+                setShowReturn(false);
+              }}
+              lang={lang}
+            />
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace calendar popover in `DateInput` with compact pill control featuring optional label
- restructure search form row so selects, dates, passengers and submit button share consistent `h-14` styling
- open calendar overlays when date pills are clicked so users can select travel dates

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac3ddf4a548327b4a01c9f2450947d