### PR TITLE
feat: show schedule and price breakdown

### DIFF
--- a/src/components/booking/BookingCard.tsx
+++ b/src/components/booking/BookingCard.tsx
@@ -7,9 +7,12 @@ import SearchResults from "@/components/search/SearchResults";
 type Criteria = {
   from: string;
   to: string;
+  fromName: string;
+  toName: string;
   date: string;
   returnDate?: string;
   seatCount: number;
+  discountCount: number;
 };
 
 export default function BookingCard() {

--- a/src/components/hero/HeroSection.tsx
+++ b/src/components/hero/HeroSection.tsx
@@ -11,9 +11,12 @@ export default function HeroSection({ lang = 'ru' }: { lang?: Lang }) {
   const [criteria, setCriteria] = useState<null | {
     from: string;
     to: string;
+    fromName: string;
+    toName: string;
     date: string;
     returnDate?: string;
     seatCount: number;
+    discountCount: number;
   }>(null);
 
   const expanded = !!criteria;
@@ -57,9 +60,12 @@ export default function HeroSection({ lang = 'ru' }: { lang?: Lang }) {
                     lang={lang}
                     from={criteria!.from}
                     to={criteria!.to}
+                    fromName={criteria!.fromName}
+                    toName={criteria!.toName}
                     date={criteria!.date}
                     returnDate={criteria!.returnDate}
                     seatCount={criteria!.seatCount}
+                    discountCount={criteria!.discountCount}
                   />
                 </div>
               </div>

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -23,9 +23,12 @@ type Props = {
   onSearch: (params: {
     from: string;
     to: string;
+    fromName: string;
+    toName: string;
     date: string;
     returnDate?: string;
     seatCount: number;
+    discountCount: number;
   }) => void;
 };
 
@@ -130,12 +133,17 @@ export default function SearchForm({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!fromId || !toId || !departDate) return;
+    const fromName = departureStops.find((s) => s.id === fromId)?.stop_name || '';
+    const toName = arrivalStops.find((s) => s.id === toId)?.stop_name || '';
     onSearch({
       from: String(fromId),
       to: String(toId),
+      fromName,
+      toName,
       date: departDate,
       returnDate: returnDate || undefined,
       seatCount,
+      discountCount: passengers.discount,
     });
   };
 

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -14,6 +14,9 @@ import BookingPanel from "./BookingPanel";
 export type Tour = {
   id: number;
   date: string;
+  departure_time: string;
+  arrival_time: string;
+  price: number;
   seats: number | { free: number };
   layout_variant?: string | null;
 };
@@ -22,9 +25,12 @@ type Props = {
   lang?: "ru" | "bg" | "en" | "ua";
   from: string;        // id остановки приходит как string
   to: string;          // id остановки приходит как string
+  fromName: string;
+  toName: string;
   date: string;        // YYYY-MM-DD
   returnDate?: string; // YYYY-MM-DD | undefined
   seatCount: number;
+  discountCount: number;
 };
 
 type Dict = {
@@ -43,6 +49,11 @@ type Dict = {
   errSearch: string;
   errAction: string;
   loading: string;
+  inRoute: string;
+  price: string;
+  total: string;
+  adults: string;
+  discounted: string;
 };
 
 const dict: Record<NonNullable<Props["lang"]>, Dict> = {
@@ -62,6 +73,11 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     errSearch: "Ошибка поиска рейсов",
     errAction: "Ошибка операции",
     loading: "Загрузка…",
+    inRoute: "В пути",
+    price: "Цена",
+    total: "Итого",
+    adults: "Взрослых",
+    discounted: "Льготных",
   },
   en: {
     noResults: "No trips found",
@@ -79,6 +95,11 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     errSearch: "Search error",
     errAction: "Operation error",
     loading: "Loading…",
+    inRoute: "Duration",
+    price: "Price",
+    total: "Total",
+    adults: "Adults",
+    discounted: "Discounted",
   },
   bg: {
     noResults: "Няма намерени курсове",
@@ -96,6 +117,11 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     errSearch: "Грешка при търсене",
     errAction: "Грешка при операция",
     loading: "Зареждане…",
+    inRoute: "В път",
+    price: "Цена",
+    total: "Общо",
+    adults: "Възрастни",
+    discounted: "С намаление",
   },
   ua: {
     noResults: "Рейси не знайдено",
@@ -113,6 +139,11 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     errSearch: "Помилка пошуку рейсів",
     errAction: "Помилка операції",
     loading: "Завантаження…",
+    inRoute: "У дорозі",
+    price: "Ціна",
+    total: "Разом",
+    adults: "Дорослих",
+    discounted: "Пільгових",
   },
 };
 
@@ -120,15 +151,19 @@ export default function SearchResults({
   lang = "ru",
   from,
   to,
+  fromName,
+  toName,
   date,
   returnDate,
   seatCount,
+  discountCount,
 }: Props) {
   const t = dict[lang];
 
   // Limit seat count to a reasonable range to avoid huge allocations
   const MAX_SEAT_COUNT = 50;
   const safeSeatCount = Math.max(1, Math.min(seatCount, MAX_SEAT_COUNT));
+  const safeDiscountCount = Math.max(0, Math.min(discountCount, safeSeatCount));
 
   // Числовые id (один раз)
   const fromId = useMemo(() => Number(from), [from]);
@@ -417,7 +452,21 @@ export default function SearchResults({
           selectedId={selectedOutboundTour?.id}
           onSelect={onSelectOutbound}
           freeSeatsValue={freeSeatsValue}
-          t={{ pick: t.pick, chosen: t.chosen, freeSeats: t.freeSeats }}
+          fromName={fromName}
+          toName={toName}
+          lang={lang}
+          seatCount={safeSeatCount}
+          discountCount={safeDiscountCount}
+          t={{
+            pick: t.pick,
+            chosen: t.chosen,
+            freeSeats: t.freeSeats,
+            inRoute: t.inRoute,
+            price: t.price,
+            total: t.total,
+            adults: t.adults,
+            discounted: t.discounted,
+          }}
         />
       )}
 
@@ -429,7 +478,21 @@ export default function SearchResults({
           selectedId={selectedReturnTour?.id}
           onSelect={onSelectReturn}
           freeSeatsValue={freeSeatsValue}
-          t={{ pick: t.pick, chosen: t.chosen, freeSeats: t.freeSeats }}
+          fromName={toName}
+          toName={fromName}
+          lang={lang}
+          seatCount={safeSeatCount}
+          discountCount={safeDiscountCount}
+          t={{
+            pick: t.pick,
+            chosen: t.chosen,
+            freeSeats: t.freeSeats,
+            inRoute: t.inRoute,
+            price: t.price,
+            total: t.total,
+            adults: t.adults,
+            discounted: t.discounted,
+          }}
         />
       )}
 

--- a/src/components/search/TripList.tsx
+++ b/src/components/search/TripList.tsx
@@ -8,10 +8,20 @@ type TripListProps = {
   selectedId?: number;
   onSelect: (tour: Tour) => void;
   freeSeatsValue: (s: Tour["seats"]) => number;
+  fromName: string;
+  toName: string;
+  lang: "ru" | "bg" | "en" | "ua";
+  seatCount: number;
+  discountCount: number;
   t: {
     pick: string;
     chosen: string;
     freeSeats: (n: number) => string;
+    inRoute: string;
+    price: string;
+    total: string;
+    adults: string;
+    discounted: string;
   };
 };
 
@@ -21,19 +31,60 @@ export default function TripList({
   selectedId,
   onSelect,
   freeSeatsValue,
+  fromName,
+  toName,
+  lang,
+  seatCount,
+  discountCount,
   t,
 }: TripListProps) {
+  const DISCOUNT = 0.05;
+
   return (
     <>
       <h3 className="mt-3 mb-2">{title}:</h3>
       {tours.map((tour) => {
         const isChosen = selectedId === tour.id;
+        const dep = new Date(tour.departure_time);
+        const arr = new Date(tour.arrival_time);
+        const dateStr = dep.toLocaleDateString(lang);
+        const depTime = dep.toLocaleTimeString(lang, { hour: "2-digit", minute: "2-digit" });
+        const arrTime = arr.toLocaleTimeString(lang, { hour: "2-digit", minute: "2-digit" });
+        const diffMinutes = Math.max(0, Math.round((arr.getTime() - dep.getTime()) / 60000));
+        const h = Math.floor(diffMinutes / 60)
+          .toString()
+          .padStart(2, "0");
+        const m = (diffMinutes % 60).toString().padStart(2, "0");
+        const duration = `${h}:${m}`;
+
+        const adults = Math.max(0, seatCount - discountCount);
+        const adultSum = adults * tour.price;
+        const discPrice = tour.price * (1 - DISCOUNT);
+        const discSum = discountCount * discPrice;
+        const total = adultSum + discSum;
+
         return (
           <div key={tour.id} className={styles.item}>
-            <span>
-              Рейс #{tour.id}, дата: {tour.date} —{" "}
-              {t.freeSeats(freeSeatsValue(tour.seats))}
-            </span>
+            <div className="flex-1">
+              <div>
+                {dateStr} {depTime} {fromName} → {arrTime} {toName} ({t.inRoute} {duration})
+              </div>
+              <div>{t.price}: {tour.price.toFixed(2)}</div>
+              {adults > 0 && (
+                <div>
+                  {adults} {t.adults} {tour.price.toFixed(2)} × {adults} = {adultSum.toFixed(2)}
+                </div>
+              )}
+              {discountCount > 0 && (
+                <div>
+                  {discountCount} {t.discounted} {tour.price.toFixed(2)} × {discountCount} -5% = {discSum.toFixed(2)}
+                </div>
+              )}
+              <div>
+                {t.total}: {total.toFixed(2)}
+              </div>
+              <div>{t.freeSeats(freeSeatsValue(tour.seats))}</div>
+            </div>
             <button
               onClick={() => onSelect(tour)}
               className={`${styles.btn} ${isChosen ? styles.chosen : styles.pick}`}


### PR DESCRIPTION
## Summary
- display formatted departure and arrival times with trip duration
- show ticket price breakdown for adults and discounted passengers
- pass stop names and passenger counts from the search form

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac48dda56c832797270cd2d5864050