### PR TITLE
Use consistent dd mm yyyy date format

### DIFF
--- a/src/components/hero/DateInput.tsx
+++ b/src/components/hero/DateInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { formatDate } from "@/utils/date";
 
 type Props = {
   value: string;
@@ -20,17 +21,11 @@ export default function DateInput({
   disabled,
   className = "",
   label,
-  lang = "ru",
+  lang = "ru", // eslint-disable-line @typescript-eslint/no-unused-vars
   onOpen,
 }: Props) {
   // отображаемое значение (если пусто — покажем "— — —")
-  const human =
-    value
-      ? new Date(value + "T00:00:00Z").toLocaleDateString(
-          lang === "en" ? "en-GB" : lang,
-          { day: "2-digit", month: "2-digit", year: "numeric" }
-        )
-      : "— — —";
+  const human = value ? formatDate(value) : "— — —";
 
   return (
     <button

--- a/src/components/search/BookingPanel.tsx
+++ b/src/components/search/BookingPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import SeatClient from "../SeatClient";
 import type { Tour } from "./SearchResults";
 import FormInput from "../common/FormInput";
+import { formatDate } from "@/utils/date";
 
 type Dict = {
   freeSeats: (n: number) => string;
@@ -84,7 +85,7 @@ export default function BookingPanel({
   return (
     <>
       <h3 className="mt-5">
-        Рейс туда #{selectedOutboundTour.id}, дата: {selectedOutboundTour.date}
+        Рейс туда #{selectedOutboundTour.id}, дата: {formatDate(selectedOutboundTour.date)}
       </h3>
       <p>{t.freeSeats(free(selectedOutboundTour.seats))}</p>
       <p>Выберите место:</p>
@@ -106,7 +107,7 @@ export default function BookingPanel({
       {selectedReturnTour && (
         <>
           <h3 className="mt-5">
-            Рейс обратно #{selectedReturnTour.id}, дата: {selectedReturnTour.date}
+            Рейс обратно #{selectedReturnTour.id}, дата: {formatDate(selectedReturnTour.date)}
           </h3>
           <p>{t.freeSeats(free(selectedReturnTour.seats))}</p>
           <p>Выберите место:</p>

--- a/src/components/search/TripList.tsx
+++ b/src/components/search/TripList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Tour } from "./SearchResults";
 import styles from "./TripList.module.css";
+import { formatDate } from "@/utils/date";
 
 type TripListProps = {
   title: string;
@@ -51,7 +52,7 @@ export default function TripList({
         if (arr.getTime() < dep.getTime()) {
           arr.setDate(arr.getDate() + 1);
         }
-        const dateStr = dep.toLocaleDateString(lang);
+        const dateStr = formatDate(dep);
         const depTime = dep.toLocaleTimeString(lang, { hour: "2-digit", minute: "2-digit" });
         const arrTime = arr.toLocaleTimeString(lang, { hour: "2-digit", minute: "2-digit" });
         const diffMinutes = Math.max(0, Math.round((arr.getTime() - dep.getTime()) / 60000));

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,10 @@
+export function formatDate(value: Date | string): string {
+  if (typeof value === "string") {
+    const [year, month, day] = value.split("-");
+    return `${day} ${month} ${year}`;
+  }
+  const day = String(value.getDate()).padStart(2, "0");
+  const month = String(value.getMonth() + 1).padStart(2, "0");
+  const year = value.getFullYear();
+  return `${day} ${month} ${year}`;
+}


### PR DESCRIPTION
## Summary
- add `formatDate` helper to produce `dd mm yyyy` dates
- apply new date format to date input, trip list, and booking panel displays

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac52a2871c8327978af9a8609a0295