### PR TITLE
Guard CSS HMR removeChild and switch to hryvnia

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "node scripts/fix-css-hmr.js"
   },
   "dependencies": {
     "axios": "^1.11.0",

--- a/scripts/fix-css-hmr.js
+++ b/scripts/fix-css-hmr.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const file = path.join(__dirname, '..', 'node_modules', 'next', 'dist', 'compiled', 'mini-css-extract-plugin', 'hmr', 'hotModuleReplacement.js');
+
+try {
+  let content = fs.readFileSync(file, 'utf8');
+  const patched = content.replace(/e\.parentNode\.removeChild\(e\)/g, 'e.parentNode && e.parentNode.removeChild(e)');
+  if (patched !== content) {
+    fs.writeFileSync(file, patched, 'utf8');
+    console.log('Patched mini-css-extract-plugin HMR to guard against null parentNode');
+  }
+} catch (err) {
+  console.error('Failed to patch mini-css-extract-plugin HMR', err);
+}

--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -55,7 +55,7 @@ export default function TripCard({
           </span>
         </div>
         <span className="text-xl font-semibold text-slate-900">
-          {total.toFixed(2)} €
+          {total.toFixed(2)} ₴
         </span>
       </div>
 
@@ -68,13 +68,13 @@ export default function TripCard({
       <div className="text-sm text-slate-600 space-y-1">
         {rows.map((r, i) => (
           <div key={i}>
-            {r.count} {r.label} × {r.price.toFixed(2)} €
+            {r.count} {r.label} × {r.price.toFixed(2)} ₴
             {r.discount ? (
               <span className="ml-1 text-emerald-600">(-{r.discount}%)</span>
             ) : null}
             {" = "}
             <span className="font-medium">
-              {(r.count * r.price * (1 - (r.discount ?? 0) / 100)).toFixed(2)} €
+              {(r.count * r.price * (1 - (r.discount ?? 0) / 100)).toFixed(2)} ₴
             </span>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- guard mini-css-extract-plugin HMR so missing parent nodes don't crash
- display prices using Ukrainian hryvnia symbol

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f81d21883278d8a86ee9b2aa615