### PR TITLE
Clarify trip date and time display

### DIFF
--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -22,6 +22,9 @@ export type TripCardProps = {
   pickLabel?: string;
   chosenLabel?: string;
   freeSeatsText?: (n: number) => string;
+  departureLabel?: string;
+  arrivalLabel?: string;
+  inRouteLabel?: string;
 };
 
 export default function TripCard({
@@ -39,6 +42,9 @@ export default function TripCard({
   pickLabel = "Выбрать",
   chosenLabel = "Выбрано",
   freeSeatsText,
+  departureLabel = "Отправление",
+  arrivalLabel = "Прибытие",
+  inRouteLabel = "В пути",
 }: TripCardProps) {
   return (
     <div
@@ -48,17 +54,19 @@ export default function TripCard({
       role="button"
       onClick={onSelect}
     >
+      {/* date */}
+      <div className="text-lg font-bold text-slate-900">{dateText}</div>
       {/* top row: departure/arrival */}
       <div className="flex justify-between items-start">
         {/* departure */}
         <div>
-          <div className="text-lg font-bold text-slate-900">
-            {dateText} • {departTime}
-          </div>
+          <div className="text-xs text-slate-500">{departureLabel}</div>
+          <div className="text-lg font-bold text-slate-900">{departTime}</div>
           <div className="text-sm text-slate-500">{fromStop}</div>
         </div>
         {/* arrival */}
         <div className="text-right">
+          <div className="text-xs text-slate-500">{arrivalLabel}</div>
           <div className="text-lg font-bold text-slate-900">{arriveTime}</div>
           <div className="text-sm text-slate-500">{toStop}</div>
         </div>
@@ -67,7 +75,7 @@ export default function TripCard({
       {/* duration */}
       <div className="flex items-center gap-2 text-sm text-slate-600">
         <Clock className="h-4 w-4" />
-        В пути: {duration}
+        {inRouteLabel}: {duration}
       </div>
 
       {/* route line */}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -50,6 +50,8 @@ type Dict = {
   errAction: string;
   loading: string;
   inRoute: string;
+  departure: string;
+  arrival: string;
   price: string;
   total: string;
   adults: string;
@@ -74,6 +76,8 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     errAction: "Ошибка операции",
     loading: "Загрузка…",
     inRoute: "В пути",
+    departure: "Отправление",
+    arrival: "Прибытие",
     price: "Цена",
     total: "Итого",
     adults: "Взрослых",
@@ -96,6 +100,8 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     errAction: "Operation error",
     loading: "Loading…",
     inRoute: "Duration",
+    departure: "Departure",
+    arrival: "Arrival",
     price: "Price",
     total: "Total",
     adults: "Adults",
@@ -118,6 +124,8 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     errAction: "Грешка при операция",
     loading: "Зареждане…",
     inRoute: "В път",
+    departure: "Отпътуване",
+    arrival: "Пристигане",
     price: "Цена",
     total: "Общо",
     adults: "Възрастни",
@@ -140,6 +148,8 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     errAction: "Помилка операції",
     loading: "Завантаження…",
     inRoute: "У дорозі",
+    departure: "Відправлення",
+    arrival: "Прибуття",
     price: "Ціна",
     total: "Разом",
     adults: "Дорослих",
@@ -457,13 +467,7 @@ export default function SearchResults({
           lang={lang}
           seatCount={safeSeatCount}
           discountCount={safeDiscountCount}
-          t={{
-            pick: t.pick,
-            chosen: t.chosen,
-            freeSeats: t.freeSeats,
-            adults: t.adults,
-            discounted: t.discounted,
-          }}
+          t={t}
         />
       )}
 
@@ -480,13 +484,7 @@ export default function SearchResults({
           lang={lang}
           seatCount={safeSeatCount}
           discountCount={safeDiscountCount}
-          t={{
-            pick: t.pick,
-            chosen: t.chosen,
-            freeSeats: t.freeSeats,
-            adults: t.adults,
-            discounted: t.discounted,
-          }}
+          t={t}
         />
       )}
 

--- a/src/components/search/TripList.tsx
+++ b/src/components/search/TripList.tsx
@@ -20,6 +20,9 @@ type TripListProps = {
     freeSeats: (n: number) => string;
     adults: string;
     discounted: string;
+    departure: string;
+    arrival: string;
+    inRoute: string;
   };
 };
 
@@ -97,6 +100,9 @@ export default function TripList({
               departTime={depTime}
               arriveTime={arrTime}
               duration={duration}
+              departureLabel={t.departure}
+              arrivalLabel={t.arrival}
+              inRouteLabel={t.inRoute}
               freeSeats={freeSeatsValue(tour.seats)}
               rows={rows}
               total={total}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,10 +1,10 @@
 export function formatDate(value: Date | string): string {
   if (typeof value === "string") {
     const [year, month, day] = value.split("-");
-    return `${day} ${month} ${year}`;
+    return `${day}/${month}/${year}`;
   }
   const day = String(value.getDate()).padStart(2, "0");
   const month = String(value.getMonth() + 1).padStart(2, "0");
   const year = value.getFullYear();
-  return `${day} ${month} ${year}`;
+  return `${day}/${month}/${year}`;
 }


### PR DESCRIPTION
## Summary
- format travel dates as `dd/mm/yyyy`
- show trip date separately with labeled departure and arrival times
- localize new labels across languages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac66bc6d348327ac2b9521e73aa23e