### PR TITLE
feat: toggle round-trip seats

### DIFF
--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -2,7 +2,7 @@ import BookingCard from "@/components/booking/BookingCard";
 
 export default function BookingPage() {
   return (
-    <main className="min-h-screen p-4 bg-sky-100">
+    <main className="min-h-screen p-4 bg-gradient-to-b from-sky-100 to-sky-200">
       <BookingCard />
     </main>
   );

--- a/src/components/search/BookingPanel.tsx
+++ b/src/components/search/BookingPanel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import SeatClient from "../SeatClient";
 import type { Tour } from "./SearchResults";
 import FormInput from "../common/FormInput";
@@ -12,6 +12,8 @@ type Dict = {
   canceled: string;
   pay: string;
   cancel: string;
+  outboundShort: string;
+  inboundShort: string;
 };
 
 type Props = {
@@ -86,33 +88,58 @@ export default function BookingPanel({
   handleCancel,
   purchaseId,
 }: Props) {
+  const [activeLeg, setActiveLeg] = useState<"outbound" | "return">("outbound");
+
   return (
     <>
-      <h3 className="mt-5">
-        Рейс туда #{selectedOutboundTour.id}, дата: {formatDate(selectedOutboundTour.date)}
-      </h3>
-      <p>{t.freeSeats(free(selectedOutboundTour.seats))}</p>
-      <p>Выберите место:</p>
-
-      <SeatClient
-        tourId={selectedOutboundTour.id}
-        departureStopId={fromId}
-        arrivalStopId={toId}
-        layoutVariant={selectedOutboundTour.layout_variant || undefined}
-        selectedSeats={selectedOutboundSeats}
-        maxSeats={seatCount}
-        onChange={setSelectedOutboundSeats}
-        departureText={`${fromName} ${selectedOutboundTour.departure_time}`}
-        arrivalText={`${toName} ${selectedOutboundTour.arrival_time}`}
-        extraBaggage={extraBaggageOutbound[0] || false}
-        onExtraBaggageChange={(v) => {
-          const arr = [...extraBaggageOutbound];
-          arr[0] = v;
-          setExtraBaggageOutbound(arr);
-        }}
-      />
-
       {selectedReturnTour && (
+        <div className="mt-5 inline-flex overflow-hidden rounded-lg border">
+          <button
+            type="button"
+            onClick={() => setActiveLeg("outbound")}
+            className={`px-4 py-2 ${activeLeg === "outbound" ? "bg-sky-600 text-white" : "bg-white text-sky-600"}`}
+          >
+            {t.outboundShort}
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveLeg("return")}
+            className={`px-4 py-2 ${activeLeg === "return" ? "bg-sky-600 text-white" : "bg-white text-sky-600"}`}
+          >
+            {t.inboundShort}
+          </button>
+        </div>
+      )}
+
+      {(!selectedReturnTour || activeLeg === "outbound") && (
+        <>
+          <h3 className="mt-5">
+            Рейс туда #{selectedOutboundTour.id}, дата: {formatDate(selectedOutboundTour.date)}
+          </h3>
+          <p>{t.freeSeats(free(selectedOutboundTour.seats))}</p>
+          <p>Выберите место:</p>
+
+          <SeatClient
+            tourId={selectedOutboundTour.id}
+            departureStopId={fromId}
+            arrivalStopId={toId}
+            layoutVariant={selectedOutboundTour.layout_variant || undefined}
+            selectedSeats={selectedOutboundSeats}
+            maxSeats={seatCount}
+            onChange={setSelectedOutboundSeats}
+            departureText={`${fromName} ${selectedOutboundTour.departure_time}`}
+            arrivalText={`${toName} ${selectedOutboundTour.arrival_time}`}
+            extraBaggage={extraBaggageOutbound[0] || false}
+            onExtraBaggageChange={(v) => {
+              const arr = [...extraBaggageOutbound];
+              arr[0] = v;
+              setExtraBaggageOutbound(arr);
+            }}
+          />
+        </>
+      )}
+
+      {selectedReturnTour && activeLeg === "return" && (
         <>
           <h3 className="mt-5">
             Рейс обратно #{selectedReturnTour.id}, дата: {formatDate(selectedReturnTour.date)}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -37,6 +37,8 @@ type Dict = {
   noResults: string;
   outbound: string;
   inbound: string;
+  outboundShort: string;
+  inboundShort: string;
   pick: string;
   chosen: string;
   freeSeats: (n: number) => string;
@@ -63,6 +65,8 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     noResults: "Рейсы не найдены",
     outbound: "Рейсы туда",
     inbound: "Рейсы обратно",
+    outboundShort: "Туда",
+    inboundShort: "Обратно",
     pick: "Выбрать",
     chosen: "Выбрано",
     freeSeats: (n) => `Свободно мест: ${n}`,
@@ -87,6 +91,8 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     noResults: "No trips found",
     outbound: "Outbound trips",
     inbound: "Return trips",
+    outboundShort: "Outbound",
+    inboundShort: "Return",
     pick: "Select",
     chosen: "Selected",
     freeSeats: (n) => `Free seats: ${n}`,
@@ -111,6 +117,8 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     noResults: "Няма намерени курсове",
     outbound: "Курсове натам",
     inbound: "Курсове обратно",
+    outboundShort: "Натам",
+    inboundShort: "Обратно",
     pick: "Избор",
     chosen: "Избрано",
     freeSeats: (n) => `Свободни места: ${n}`,
@@ -135,6 +143,8 @@ const dict: Record<NonNullable<Props["lang"]>, Dict> = {
     noResults: "Рейси не знайдено",
     outbound: "Рейси туди",
     inbound: "Рейси назад",
+    outboundShort: "Туди",
+    inboundShort: "Назад",
     pick: "Обрати",
     chosen: "Обрано",
     freeSeats: (n) => `Вільних місць: ${n}`,


### PR DESCRIPTION
## Summary
- add toggle buttons to switch between outbound and return seat selections
- support short translations for trip directions
- extend booking page background to full gradient

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad591b46fc83278ffa45c03b35d182