### PR TITLE
feat: load price list from api

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ export default function Page() {
 
       <section id="schedule" className="bg-slate-50">
         <div className="mx-auto max-w-6xl w-full px-4 py-14">
-          <Schedule />
+          <Schedule lang={lang} />
         </div>
       </section>
 

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -1,35 +1,116 @@
-// src/components/Schedule.tsx
-const translations = {
-  ru: { schedule: "Цены и расписание", route: "Маршрут", time: "Время", price: "Цена" },
-  bg: { schedule: "Цени и разписание", route: "Маршрут", time: "Час", price: "Цена" },
-  en: { schedule: "Prices and schedule", route: "Route", time: "Time", price: "Price" },
-  ua: { schedule: "Ціни та розклад", route: "Маршрут", time: "Час", price: "Ціна" },
+"use client";
+
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+import { API } from "@/config";
+
+type Lang = "ru" | "bg" | "en" | "ua";
+
+type PriceItem = {
+  departure_stop_id: number;
+  departure_name: string;
+  arrival_stop_id: number;
+  arrival_name: string;
+  price: number;
 };
 
-export default function Schedule({ lang = "ru" }: { lang?: "ru" | "bg" | "en" | "ua" }) {
+type Dict = {
+  schedule: string;
+  route: string;
+  price: string;
+  loading: string;
+  error: string;
+  noData: string;
+};
+
+const translations: Record<Lang, Dict> = {
+  ru: {
+    schedule: "Цены",
+    route: "Маршрут",
+    price: "Цена",
+    loading: "Загрузка…",
+    error: "Ошибка загрузки",
+    noData: "Данные не найдены",
+  },
+  bg: {
+    schedule: "Цени",
+    route: "Маршрут",
+    price: "Цена",
+    loading: "Зареждане…",
+    error: "Грешка при зареждането",
+    noData: "Няма данни",
+  },
+  en: {
+    schedule: "Prices",
+    route: "Route",
+    price: "Price",
+    loading: "Loading…",
+    error: "Failed to load",
+    noData: "No data",
+  },
+  ua: {
+    schedule: "Ціни",
+    route: "Маршрут",
+    price: "Ціна",
+    loading: "Завантаження…",
+    error: "Помилка завантаження",
+    noData: "Даних немає",
+  },
+};
+
+export default function Schedule({ lang = "ru" }: { lang?: Lang }) {
   const t = translations[lang];
+  const [prices, setPrices] = useState<PriceItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const fetchPrices = async () => {
+      try {
+        const { data } = await axios.post(`${API}/selected_pricelist`, { lang });
+        setPrices(data?.prices || []);
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPrices();
+  }, [lang]);
+
   return (
     <section className="bg-gray-50 py-14" id="prices">
       <div className="container mx-auto px-4">
         <h2 className="text-2xl font-semibold text-center mb-8">{t.schedule}</h2>
-        <div className="overflow-x-auto">
-          <table className="min-w-full bg-white rounded-xl text-left">
-            <thead>
-              <tr>
-                <th className="px-6 py-4">{t.route}</th>
-                <th className="px-6 py-4">{t.time}</th>
-                <th className="px-6 py-4">{t.price}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td className="px-6 py-4">София — Варна</td>
-                <td className="px-6 py-4">08:00, 15:30</td>
-                <td className="px-6 py-4">50 лв</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        {loading ? (
+          <p className="text-center">{t.loading}</p>
+        ) : error ? (
+          <p className="text-center text-red-500">{t.error}</p>
+        ) : prices.length === 0 ? (
+          <p className="text-center">{t.noData}</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full bg-white rounded-xl text-left">
+              <thead>
+                <tr>
+                  <th className="px-6 py-4">{t.route}</th>
+                  <th className="px-6 py-4">{t.price}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {prices.map((p, i) => (
+                  <tr key={`${p.departure_stop_id}-${p.arrival_stop_id}-${i}`}>
+                    <td className="px-6 py-4">
+                      {p.departure_name.trim()} — {p.arrival_name.trim()}
+                    </td>
+                    <td className="px-6 py-4">{p.price}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- fetch price list from backend and render table
- localize price section and wire language from page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad8a7be9ac8327890a4c8ce29f7cef