### PR TITLE
feat: centralize language state and translations

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 // общие компоненты
 import Header from "@/components/Header";
 import SiteFooter from "@/components/SiteFooter";
+import { LanguageProvider } from "@/components/common/LanguageProvider";
 
 export const metadata = {
   title: "Максимов Турc",
@@ -14,14 +15,16 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ru">
       <body className="min-h-screen antialiased bg-slate-50 text-slate-900">
-        {/* Общая шапка сайта */}
-        <Header />
+        <LanguageProvider>
+          {/* Общая шапка сайта */}
+          <Header />
 
-        {/* Контент страницы */}
-        {children}
+          {/* Контент страницы */}
+          {children}
 
-        {/* Общий футер сайта */}
-        <SiteFooter />
+          {/* Общий футер сайта */}
+          <SiteFooter />
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,13 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-
 import HeroSection from "@/components/hero/HeroSection";
 import Routes from "@/components/Routes";
 import Schedule from "@/components/Schedule";
 import About from "@/components/About";
-
-type Lang = "ru" | "bg" | "en" | "ua";
+import { useLanguage } from "@/components/common/LanguageProvider";
 
 export default function Page() {
-  const [lang, setLang] = useState<Lang>("ru");
-
-  useEffect(() => {
-    const nav = navigator.language.slice(0, 2) as Lang;
-    if (["ru", "bg", "en", "ua"].includes(nav)) {
-      setLang(nav);
-    }
-  }, []);
+  const { lang } = useLanguage();
 
   return (
     <main className="min-h-screen">

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -2,11 +2,14 @@
 "use client";
 
 import AboutSection from "@/components/about/AboutSection";
+import { useLanguage } from "@/components/common/LanguageProvider";
 
 export default function About() {
+  const { lang } = useLanguage();
+
   return (
     <div id="about">
-      <AboutSection lang="ru" />
+      <AboutSection lang={lang} />
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,8 @@
 // src/components/Header.tsx
 "use client";
 
-import React, { useState, useEffect } from "react";
 import Link from "next/link";
-
-type Lang = "ru" | "bg" | "en" | "ua";
+import { useLanguage, type Lang } from "@/components/common/LanguageProvider";
 
 const menu = [
   { href: "#hero",    label: { ru: "Билеты",       bg: "Билети",       en: "Tickets",   ua: "Квитки"   } },
@@ -15,24 +13,11 @@ const menu = [
   { href: "#contacts",label: { ru: "Контакты",     bg: "Контакти",     en: "Contacts",  ua: "Контакти" } },
 ];
 
-interface HeaderProps {
-  /** Начальный язык (если не передать — RU) */
-  lang?: Lang;
-  /** Опционально: сообщить наружу о смене языка */
-  onLangChange?: (lang: Lang) => void;
-}
-
-export default function Header({ lang = "ru", onLangChange }: HeaderProps) {
-  // локальное состояние чтобы избежать гидрации и не требовать серверный обработчик
-  const [current, setCurrent] = useState<Lang>(lang);
-
-  useEffect(() => {
-    setCurrent(lang); // если проп поменяли сверху — синхронизируем
-  }, [lang]);
+export default function Header() {
+  const { lang: current, setLang } = useLanguage();
 
   const handleChange = (v: Lang) => {
-    setCurrent(v);
-    onLangChange?.(v);
+    setLang(v);
   };
 
   return (

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -4,17 +4,15 @@
 import React, { useEffect, useMemo, useState } from "react";
 import {
   Clock,
-  LogIn,
   LogOut,
   MapPin,
   ChevronDown,
   ChevronUp,
 } from "lucide-react";
 import { API } from "@/config";
+import { useLanguage, type Lang } from "@/components/common/LanguageProvider";
 
 /* ===================== Types ===================== */
-
-type Lang = "ru" | "bg" | "en" | "ua";
 
 type Stop = {
   id: number;
@@ -145,7 +143,8 @@ const lastTime = (s?: Stop[]) =>
 
 /* ===================== Component ===================== */
 
-export default function Routes({ lang = "ru" }: { lang?: Lang }) {
+export default function Routes() {
+  const { lang } = useLanguage();
   const L = T[lang];
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -282,7 +281,7 @@ function RoutePanel({
       </div>
 
       {/* Rail */}
-      <StopsList stops={route.stops} lang={lang} />
+    <StopsList stops={route.stops} lang={lang} />
     </div>
   );
 }

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,12 +1,57 @@
+"use client";
+
+import { useLanguage } from "@/components/common/LanguageProvider";
+
 // src/components/SiteFooter.tsx
 const translations = {
-  ru: { nav: "Навигация", docs: "Документы", offer: "Публичная оферта", agreement: "Пользовательское соглашение", contacts: "Контакты" },
-  bg: { nav: "Навигация", docs: "Документи", offer: "Публична оферта", agreement: "Потребителско споразумение", contacts: "Контакти" },
-  en: { nav: "Navigation", docs: "Documents", offer: "Public offer", agreement: "User agreement", contacts: "Contacts" },
-  ua: { nav: "Навігація", docs: "Документи", offer: "Публічна оферта", agreement: "Користувацька угода", contacts: "Контакти" },
+  ru: {
+    nav: "Навигация",
+    docs: "Документы",
+    offer: "Публичная оферта",
+    agreement: "Пользовательское соглашение",
+    contacts: "Контакты",
+    popular: "Направления",
+    routes: "Маршруты",
+    about: "О нас",
+    schedule: "Расписание",
+  },
+  bg: {
+    nav: "Навигация",
+    docs: "Документи",
+    offer: "Публична оферта",
+    agreement: "Потребителско споразумение",
+    contacts: "Контакти",
+    popular: "Дестинации",
+    routes: "Маршрути",
+    about: "За нас",
+    schedule: "Разписание",
+  },
+  en: {
+    nav: "Navigation",
+    docs: "Documents",
+    offer: "Public offer",
+    agreement: "User agreement",
+    contacts: "Contacts",
+    popular: "Destinations",
+    routes: "Routes",
+    about: "About",
+    schedule: "Schedule",
+  },
+  ua: {
+    nav: "Навігація",
+    docs: "Документи",
+    offer: "Публічна оферта",
+    agreement: "Користувацька угода",
+    contacts: "Контакти",
+    popular: "Напрями",
+    routes: "Маршрути",
+    about: "Про нас",
+    schedule: "Розклад",
+  },
 };
 
-export default function SiteFooter({ lang = "ru" }: { lang?: "ru" | "bg" | "en" | "ua" }) {
+export default function SiteFooter() {
+  const { lang } = useLanguage();
   const t = translations[lang];
   return (
     <footer className="bg-primary-dark text-gray-100 py-10">
@@ -18,10 +63,10 @@ export default function SiteFooter({ lang = "ru" }: { lang?: "ru" | "bg" | "en" 
         <div>
           <h4 className="font-semibold mb-2">{t.nav}</h4>
           <ul>
-            <li><a href="#popular" className="hover:underline">{t.nav}</a></li>
-            <li><a href="#routes" className="hover:underline">Маршруты</a></li>
-            <li><a href="#about" className="hover:underline">О нас</a></li>
-            <li><a href="#prices" className="hover:underline">Расписание</a></li>
+            <li><a href="#popular" className="hover:underline">{t.popular}</a></li>
+            <li><a href="#routes" className="hover:underline">{t.routes}</a></li>
+            <li><a href="#about" className="hover:underline">{t.about}</a></li>
+            <li><a href="#prices" className="hover:underline">{t.schedule}</a></li>
           </ul>
         </div>
         <div>

--- a/src/components/booking/BookingCard.tsx
+++ b/src/components/booking/BookingCard.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import SearchForm from "@/components/hero/SearchForm";
 import SearchResults from "@/components/search/SearchResults";
+import { useLanguage } from "@/components/common/LanguageProvider";
 
 type Criteria = {
   from: string;
@@ -17,7 +18,7 @@ type Criteria = {
 
 export default function BookingCard() {
   const [criteria, setCriteria] = useState<Criteria | null>(null);
-  const lang = "ru" as const;
+  const { lang } = useLanguage();
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6">

--- a/src/components/common/LanguageProvider.tsx
+++ b/src/components/common/LanguageProvider.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type Lang = "ru" | "bg" | "en" | "ua";
+
+const SUPPORTED_LANGS: Lang[] = ["ru", "bg", "en", "ua"];
+
+type LanguageContextValue = {
+  lang: Lang;
+  setLang: (lang: Lang) => void;
+};
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+type ProviderProps = {
+  initialLang?: Lang;
+  children: ReactNode;
+};
+
+function normalize(value: string | null | undefined): Lang | null {
+  if (!value) return null;
+  const short = value.slice(0, 2).toLowerCase();
+  return SUPPORTED_LANGS.includes(short as Lang) ? (short as Lang) : null;
+}
+
+export function LanguageProvider({ initialLang = "ru", children }: ProviderProps) {
+  const [lang, setLangState] = useState<Lang>(initialLang);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const stored = normalize(window.localStorage.getItem("mt-lang"));
+    if (stored) {
+      setLangState(stored);
+      return;
+    }
+
+    const fromNavigator = normalize(window.navigator?.language);
+    if (fromNavigator) {
+      setLangState(fromNavigator);
+    }
+  }, []);
+
+  const setLang = useCallback((next: Lang) => {
+    setLangState(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("mt-lang", next);
+    }
+  }, []);
+
+  const value = useMemo(() => ({ lang, setLang }), [lang, setLang]);
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+  return context;
+}
+

--- a/src/components/hero/HeroSection.tsx
+++ b/src/components/hero/HeroSection.tsx
@@ -1,13 +1,14 @@
 // src/components/hero/HeroSection.tsx
-'use client';
+"use client";
 
-import { useState } from 'react';
-import SearchForm from './SearchForm';
-import SearchResults from '@/components/search/SearchResults';
+import { useState } from "react";
+import SearchForm from "./SearchForm";
+import SearchResults from "@/components/search/SearchResults";
+import { translations as heroTranslations } from "@/i18n";
 
-type Lang = 'ru' | 'bg' | 'en' | 'ua';
+type Lang = "ru" | "bg" | "en" | "ua";
 
-export default function HeroSection({ lang = 'ru' }: { lang?: Lang }) {
+export default function HeroSection({ lang = "ru" }: { lang?: Lang }) {
   const [criteria, setCriteria] = useState<null | {
     from: string;
     to: string;
@@ -28,10 +29,10 @@ export default function HeroSection({ lang = 'ru' }: { lang?: Lang }) {
     >
       <div className="container mx-auto px-4 py-14">
         <h1 className="text-4xl md:text-5xl font-bold text-center">
-          Поедем с комфортом
+          {heroTranslations[lang].title}
         </h1>
         <p className="mt-3 text-center text-white/90">
-          Покупка автобусных билетов онлайн — быстро и удобно.
+          {heroTranslations[lang].subtitle}
         </p>
 
         {/* ЕДИНАЯ КАПСУЛА: форма + (скрываемый) блок результатов */}
@@ -72,6 +73,10 @@ export default function HeroSection({ lang = 'ru' }: { lang?: Lang }) {
             )}
           </div>
         </div>
+
+        <p className="mt-6 text-center text-sm text-white/80">
+          {heroTranslations[lang].note}
+        </p>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add a language context provider that persists the selected locale and exposes a setter across the app
- wire the provider into the layout so the header, landing sections, footer, and booking flow react to language changes and request backend data with the right locale
- update hero and footer content to use translation dictionaries and show the localized marketing copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d672977ff08327b75f0b596fb7de6f