### PR TITLE
Add floating PDF download prompt after booking

### DIFF
--- a/src/components/search/ElectronicTicket.tsx
+++ b/src/components/search/ElectronicTicket.tsx
@@ -3,8 +3,9 @@
 import { useMemo } from "react";
 
 import { formatDate } from "@/utils/date";
+import { downloadTicketPdf } from "@/utils/ticketPdf";
 
-import type { ElectronicTicketData } from "./SearchResults";
+import type { ElectronicTicketData } from "@/types/ticket";
 
 type Props = {
   ticket: ElectronicTicketData;
@@ -46,43 +47,7 @@ export default function ElectronicTicket({ ticket, t }: Props) {
   );
 
   const downloadTicket = () => {
-    const lines: string[] = [];
-    lines.push(`${t.ticketTitle}`);
-    lines.push(`${t.ticketNumber}: ${ticket.purchaseId}`);
-    lines.push(
-      `${t.ticketStatus}: ${t[statusMap[ticket.status]]} (${ticket.action === "purchase" ? t.ticketActionPurchase : t.ticketActionBook})`
-    );
-    lines.push(`${t.ticketCreated}: ${formattedCreatedAt}`);
-    lines.push(`${t.ticketTotal}: ${ticket.total.toFixed(2)}`);
-    lines.push(`${t.ticketContacts}: ${ticket.contact.phone}, ${ticket.contact.email}`);
-    lines.push(`${t.ticketOutbound}: ${ticket.outbound.fromName} → ${ticket.outbound.toName}`);
-    if (ticket.inbound) {
-      lines.push(`${t.ticketReturn}: ${ticket.inbound.fromName} → ${ticket.inbound.toName}`);
-    }
-    lines.push(`${t.ticketPassengers}:`);
-    ticket.passengers.forEach((passenger, idx) => {
-      lines.push(
-        `  ${idx + 1}. ${passenger.name} | ${t.ticketPassengerSeat}: ${passenger.seatOutbound ?? "-"} | ${t.ticketPassengerSeatReturn}: ${passenger.seatReturn ?? "-"}`
-      );
-      lines.push(
-        `     ${t.ticketPassengerBaggage}: ${passenger.extraBaggageOutbound ? t.ticketYes : t.ticketNo}` +
-          (ticket.inbound
-            ? ` | ${t.ticketPassengerBaggageReturn}: ${passenger.extraBaggageReturn ? t.ticketYes : t.ticketNo}`
-            : "")
-      );
-    });
-
-    const blob = new Blob([lines.join("\n")], {
-      type: "text/plain;charset=utf-8",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `ticket-${ticket.purchaseId}.txt`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    downloadTicketPdf(ticket, t);
   };
 
   const renderSegment = (label: string, segment: ElectronicTicketData["outbound"]) => (

--- a/src/components/search/TicketDownloadPrompt.tsx
+++ b/src/components/search/TicketDownloadPrompt.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect } from "react";
+
+type Translation = {
+  ticketDownloadReady: string;
+  ticketDownload: string;
+  ticketDownloadDismiss: string;
+};
+
+type Props = {
+  visible: boolean;
+  t: Translation;
+  onDownload: () => void;
+  onClose: () => void;
+};
+
+export default function TicketDownloadPrompt({
+  visible,
+  t,
+  onDownload,
+  onClose,
+}: Props) {
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    const timer = window.setTimeout(onClose, 15000);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [visible, onClose]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed bottom-6 right-6 z-50 w-full max-w-xs sm:max-w-sm">
+      <div className="pointer-events-auto rounded-3xl border border-sky-200 bg-white/95 p-4 shadow-xl backdrop-blur">
+        <div className="flex items-start justify-between gap-3">
+          <h4 className="text-base font-semibold text-sky-900">
+            {t.ticketDownloadReady}
+          </h4>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t.ticketDownloadDismiss}
+            className="rounded-full border border-transparent p-1 text-slate-500 transition hover:border-slate-300 hover:bg-slate-100 hover:text-slate-700"
+          >
+            ×
+          </button>
+        </div>
+        <div className="mt-4 flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={onDownload}
+            className="w-full rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-700"
+          >
+            {t.ticketDownload}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm font-medium text-slate-500 transition hover:text-slate-700"
+          >
+            {t.ticketDownloadDismiss}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/types/ticket.ts
+++ b/src/types/ticket.ts
@@ -1,0 +1,34 @@
+export type TicketStatus = "pending" | "paid" | "canceled";
+
+export type TicketSegment = {
+  fromName: string;
+  toName: string;
+  date: string;
+  departure_time: string;
+  arrival_time: string;
+  seatNumbers: number[];
+  extraBaggage: boolean[];
+};
+
+export type ElectronicTicketPassenger = {
+  name: string;
+  seatOutbound: number | null;
+  seatReturn: number | null;
+  extraBaggageOutbound: boolean;
+  extraBaggageReturn: boolean;
+};
+
+export type ElectronicTicketData = {
+  purchaseId: number;
+  action: "book" | "purchase";
+  total: number;
+  createdAt: string;
+  status: TicketStatus;
+  contact: {
+    phone: string;
+    email: string;
+  };
+  outbound: TicketSegment;
+  inbound?: TicketSegment | null;
+  passengers: ElectronicTicketPassenger[];
+};

--- a/src/utils/ticketPdf.ts
+++ b/src/utils/ticketPdf.ts
@@ -1,0 +1,253 @@
+import { formatDate } from "./date";
+
+import type { ElectronicTicketData } from "@/types/ticket";
+
+const statusMap: Record<
+  ElectronicTicketData["status"],
+  "ticketStatusPaid" | "ticketStatusPending" | "ticketStatusCanceled"
+> = {
+  paid: "ticketStatusPaid",
+  pending: "ticketStatusPending",
+  canceled: "ticketStatusCanceled",
+};
+
+const translitMap: Record<string, string> = {
+  А: "A",
+  а: "a",
+  Б: "B",
+  б: "b",
+  В: "V",
+  в: "v",
+  Г: "G",
+  г: "g",
+  Д: "D",
+  д: "d",
+  Е: "E",
+  е: "e",
+  Ё: "Yo",
+  ё: "yo",
+  Ж: "Zh",
+  ж: "zh",
+  З: "Z",
+  з: "z",
+  И: "I",
+  и: "i",
+  Й: "Y",
+  й: "y",
+  К: "K",
+  к: "k",
+  Л: "L",
+  л: "l",
+  М: "M",
+  м: "m",
+  Н: "N",
+  н: "n",
+  О: "O",
+  о: "o",
+  П: "P",
+  п: "p",
+  Р: "R",
+  р: "r",
+  С: "S",
+  с: "s",
+  Т: "T",
+  т: "t",
+  У: "U",
+  у: "u",
+  Ф: "F",
+  ф: "f",
+  Х: "Kh",
+  х: "kh",
+  Ц: "Ts",
+  ц: "ts",
+  Ч: "Ch",
+  ч: "ch",
+  Ш: "Sh",
+  ш: "sh",
+  Щ: "Shch",
+  щ: "shch",
+  Ъ: "A",
+  ъ: "a",
+  Ы: "Y",
+  ы: "y",
+  Ь: "",
+  ь: "",
+  Э: "E",
+  э: "e",
+  Ю: "Yu",
+  ю: "yu",
+  Я: "Ya",
+  я: "ya",
+  Ї: "Yi",
+  ї: "yi",
+  І: "I",
+  і: "i",
+  Є: "Ye",
+  є: "ye",
+  Ґ: "G",
+  ґ: "g",
+};
+
+const transliterate = (value: string): string =>
+  value
+    .split("")
+    .map((char) => translitMap[char] ?? char)
+    .join("");
+
+const sanitize = (value: string): string => {
+  const ascii = transliterate(value);
+  let result = "";
+  for (let i = 0; i < ascii.length; i += 1) {
+    const code = ascii.charCodeAt(i);
+    if (
+      code === 9 ||
+      code === 10 ||
+      code === 13 ||
+      (code >= 32 && code <= 126)
+    ) {
+      result += ascii[i];
+    }
+  }
+  return result;
+};
+
+const escapePdfText = (value: string): string =>
+  sanitize(value).replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+
+type TicketPdfLocale = {
+  ticketTitle: string;
+  ticketNumber: string;
+  ticketActionPurchase: string;
+  ticketActionBook: string;
+  ticketCreated: string;
+  ticketStatus: string;
+  ticketStatusPaid: string;
+  ticketStatusPending: string;
+  ticketStatusCanceled: string;
+  ticketTotal: string;
+  ticketContacts: string;
+  ticketPassengers: string;
+  ticketPassengerSeat: string;
+  ticketPassengerSeatReturn: string;
+  ticketPassengerBaggage: string;
+  ticketPassengerBaggageReturn: string;
+  ticketYes: string;
+  ticketNo: string;
+  ticketDownload: string;
+  ticketOutbound: string;
+  ticketReturn: string;
+};
+
+const buildPdf = (lines: string[]): string => {
+  const contentLines = lines.map((line) => `(${escapePdfText(line)}) Tj`);
+  const textStream = [
+    "BT",
+    "/F1 12 Tf",
+    "72 802 Td",
+    "14 TL",
+    contentLines.join("\nT*\n"),
+    "ET",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const objects = [
+    "1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj",
+    "2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj",
+    "3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj",
+    `4 0 obj << /Length ${textStream.length} >> stream\n${textStream}\nendstream\nendobj`,
+    "5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj",
+  ];
+
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+
+  objects.forEach((obj) => {
+    offsets.push(pdf.length);
+    pdf += `${obj}\n`;
+  });
+
+  const xrefPosition = pdf.length;
+  const totalObjects = objects.length + 1;
+  pdf += `xref\n0 ${totalObjects}\n0000000000 65535 f \n`;
+  for (let i = 1; i < offsets.length; i += 1) {
+    pdf += `${offsets[i].toString().padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer << /Size ${totalObjects} /Root 1 0 R >>\nstartxref\n${xrefPosition}\n%%EOF`;
+
+  return pdf;
+};
+
+export const downloadTicketPdf = (
+  ticket: ElectronicTicketData,
+  t: TicketPdfLocale
+) => {
+  const lines: string[] = [];
+  const actionLabel =
+    ticket.action === "purchase" ? t.ticketActionPurchase : t.ticketActionBook;
+  const statusLabel = t[statusMap[ticket.status]];
+  lines.push(t.ticketTitle);
+  lines.push(`${t.ticketNumber}: ${ticket.purchaseId}`);
+  lines.push(`${t.ticketStatus}: ${statusLabel} (${actionLabel})`);
+  lines.push(`${t.ticketCreated}: ${formatDate(new Date(ticket.createdAt))}`);
+  lines.push(`${t.ticketTotal}: ${ticket.total.toFixed(2)}`);
+  lines.push(
+    `${t.ticketContacts}: ${ticket.contact.phone}, ${ticket.contact.email}`
+  );
+  lines.push(
+    `${t.ticketOutbound}: ${ticket.outbound.fromName} -> ${ticket.outbound.toName}`
+  );
+  lines.push(
+    `  ${formatDate(ticket.outbound.date)} · ${ticket.outbound.departure_time} - ${ticket.outbound.arrival_time}`
+  );
+  if (ticket.inbound) {
+    lines.push(
+      `${t.ticketReturn}: ${ticket.inbound.fromName} -> ${ticket.inbound.toName}`
+    );
+    lines.push(
+      `  ${formatDate(ticket.inbound.date)} · ${ticket.inbound.departure_time} - ${ticket.inbound.arrival_time}`
+    );
+  }
+
+  lines.push("");
+  lines.push(`${t.ticketPassengers}:`);
+  ticket.passengers.forEach((passenger, index) => {
+    lines.push(`${index + 1}. ${passenger.name}`);
+    lines.push(
+      `   ${t.ticketPassengerSeat}: ${
+        passenger.seatOutbound ?? "-"
+      }`
+    );
+    if (ticket.inbound) {
+      lines.push(
+        `   ${t.ticketPassengerSeatReturn}: ${
+          passenger.seatReturn ?? "-"
+        }`
+      );
+    }
+    lines.push(
+      `   ${t.ticketPassengerBaggage}: ${
+        passenger.extraBaggageOutbound ? t.ticketYes : t.ticketNo
+      }`
+    );
+    if (ticket.inbound) {
+      lines.push(
+        `   ${t.ticketPassengerBaggageReturn}: ${
+          passenger.extraBaggageReturn ? t.ticketYes : t.ticketNo
+        }`
+      );
+    }
+    lines.push("");
+  });
+
+  const pdf = buildPdf(lines);
+  const blob = new Blob([pdf], { type: "application/pdf" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `ticket-${ticket.purchaseId}.pdf`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
## Summary
- add shared ticket typing and a utility to export ticket data as a lightweight PDF
- update the booking flow to surface a floating download prompt and wire it to the PDF generator
- switch the electronic ticket view to reuse the PDF exporter instead of producing text files

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9737c27d483278887b9fa57fae6a3