### PR TITLE
Include passenger counts in booking payload

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -482,13 +482,16 @@ export default function SearchResults({
         passenger_names: passengerNames,
         passenger_phone: phone,
         passenger_email: email,
+        adult_count: safeSeatCount - safeDiscountCount,
+        discount_count: safeDiscountCount,
+        ...(lang ? { lang } : {}),
       };
 
       // туда
       const outRes = await axios.post(`${API}/${endpoint}`, {
         ...basePayload,
         seat_nums: selectedOutboundSeats,
-        extra_baggage: extraBaggageOutbound,
+        extra_baggage: extraBaggageOutbound.slice(0, safeSeatCount),
         tour_id: selectedOutboundTour.id,
         departure_stop_id: fromId,
         arrival_stop_id: toId,
@@ -502,7 +505,7 @@ export default function SearchResults({
         const retRes = await axios.post(`${API}/${endpoint}`, {
           ...basePayload,
           seat_nums: selectedReturnSeats,
-          extra_baggage: extraBaggageReturn,
+          extra_baggage: extraBaggageReturn.slice(0, safeSeatCount),
           tour_id: selectedReturnTour.id,
           departure_stop_id: toId,
           arrival_stop_id: fromId,


### PR DESCRIPTION
## Summary
- include passenger and language metadata in the booking payload that is sent to the API
- trim extra baggage arrays to the requested seat count when booking round and return legs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d996e2476c8327868d87e3672a9e60