### PR TITLE
Add ticket PDF download from booking panel

### DIFF
--- a/src/components/search/BookingPanel.tsx
+++ b/src/components/search/BookingPanel.tsx
@@ -14,6 +14,7 @@ type Dict = {
   cancel: string;
   outboundShort: string;
   inboundShort: string;
+  ticketDownload: string;
 };
 
 type Props = {
@@ -52,6 +53,7 @@ type Props = {
   handlePay: () => void;
   handleCancel: () => void;
   purchaseId: number | null;
+  onDownloadTicket: (purchaseId: number) => void;
 };
 
 const free = (s: Tour["seats"]) => (typeof s === "number" ? s : s?.free ?? 0);
@@ -87,6 +89,7 @@ export default function BookingPanel({
   handlePay,
   handleCancel,
   purchaseId,
+  onDownloadTicket,
 }: Props) {
   const [activeLeg, setActiveLeg] = useState<"outbound" | "return">("outbound");
 
@@ -262,6 +265,13 @@ export default function BookingPanel({
                 className="border rounded p-2 hover:bg-slate-100"
               >
                 {t.cancel}
+              </button>
+              <button
+                type="button"
+                onClick={() => onDownloadTicket(purchaseId)}
+                className="border rounded p-2 hover:bg-slate-100"
+              >
+                {t.ticketDownload}
               </button>
             </>
           )}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -648,13 +648,16 @@ export default function SearchResults({
     }
   };
 
-  const handleTicketDownload = async () => {
-    if (!ticket) {
+  const handleTicketDownload = async (purchaseIdOverride?: number) => {
+    const targetPurchaseId = purchaseIdOverride ?? ticket?.purchaseId;
+    if (!targetPurchaseId) {
       return;
     }
 
+    const resolvedLang: NonNullable<Props["lang"]> = lang ?? "ru";
+
     try {
-      await downloadTicketPdf(ticket.purchaseId, lang);
+      await downloadTicketPdf(targetPurchaseId, resolvedLang);
       setShowDownloadPrompt(false);
     } catch (error) {
       console.error(error);
@@ -663,8 +666,8 @@ export default function SearchResults({
     }
   };
 
-  const handleTicketDownloadClick = () => {
-    void handleTicketDownload();
+  const handleTicketDownloadClick = (purchaseIdOverride?: number) => {
+    void handleTicketDownload(purchaseIdOverride);
   };
 
   const handlePromptClose = () => {
@@ -717,47 +720,48 @@ export default function SearchResults({
       {/* ВЫБОР МЕСТ + ФОРМА */}
       {selectedOutboundTour &&
         (!returnDate || (returnDate && selectedReturnTour)) && (
-          <BookingPanel
-            t={t}
-            seatCount={safeSeatCount}
-            fromId={fromId}
-            toId={toId}
-            fromName={fromName}
-            toName={toName}
-            selectedOutboundTour={selectedOutboundTour}
-            selectedReturnTour={selectedReturnTour}
-            selectedOutboundSeats={selectedOutboundSeats}
-            setSelectedOutboundSeats={setSelectedOutboundSeats}
-            selectedReturnSeats={selectedReturnSeats}
-            setSelectedReturnSeats={setSelectedReturnSeats}
-            passengerNames={passengerNames}
-            setPassengerNames={setPassengerNames}
-            phone={phone}
-            setPhone={setPhone}
-            email={email}
-            setEmail={setEmail}
-            extraBaggageOutbound={extraBaggageOutbound}
-            setExtraBaggageOutbound={setExtraBaggageOutbound}
-            extraBaggageReturn={extraBaggageReturn}
-            setExtraBaggageReturn={setExtraBaggageReturn}
-            handleAction={handleAction}
-            handlePay={handlePay}
-            handleCancel={handleCancel}
-            purchaseId={purchaseId}
-          />
-        )}
+        <BookingPanel
+          t={t}
+          seatCount={safeSeatCount}
+          fromId={fromId}
+          toId={toId}
+          fromName={fromName}
+          toName={toName}
+          selectedOutboundTour={selectedOutboundTour}
+          selectedReturnTour={selectedReturnTour}
+          selectedOutboundSeats={selectedOutboundSeats}
+          setSelectedOutboundSeats={setSelectedOutboundSeats}
+          selectedReturnSeats={selectedReturnSeats}
+          setSelectedReturnSeats={setSelectedReturnSeats}
+          passengerNames={passengerNames}
+          setPassengerNames={setPassengerNames}
+          phone={phone}
+          setPhone={setPhone}
+          email={email}
+          setEmail={setEmail}
+          extraBaggageOutbound={extraBaggageOutbound}
+          setExtraBaggageOutbound={setExtraBaggageOutbound}
+          extraBaggageReturn={extraBaggageReturn}
+          setExtraBaggageReturn={setExtraBaggageReturn}
+          handleAction={handleAction}
+          handlePay={handlePay}
+          handleCancel={handleCancel}
+          purchaseId={purchaseId}
+          onDownloadTicket={handleTicketDownloadClick}
+        />
+      )}
 
       {ticket && (
         <ElectronicTicket
           ticket={ticket}
           t={t}
-          onDownload={handleTicketDownloadClick}
+          onDownload={() => handleTicketDownloadClick()}
         />
       )}
       <TicketDownloadPrompt
         visible={showDownloadPrompt && !!ticket}
         t={t}
-        onDownload={handleTicketDownloadClick}
+        onDownload={() => handleTicketDownloadClick()}
         onClose={handlePromptClose}
       />
     </div>


### PR DESCRIPTION
## Summary
- add a PDF download action to the booking panel whenever a purchase is available
- reuse the shared ticket download handler so other views can trigger a PDF export by purchase id

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da6541902c8327b880738363762e2c