### PR TITLE
Add ticket PDF download from booking panel

### DIFF
--- a/src/components/search/BookingPanel.tsx
+++ b/src/components/search/BookingPanel.tsx
@@ -14,6 +14,7 @@ type Dict = {
   cancel: string;
   outboundShort: string;
   inboundShort: string;
+  ticketDownload: string;
 };
 
 type Props = {
@@ -52,6 +53,7 @@ type Props = {
   handlePay: () => void;
   handleCancel: () => void;
   purchaseId: number | null;
+  onDownloadTicket: (purchaseId: number) => void;
 };
 
 const free = (s: Tour["seats"]) => (typeof s === "number" ? s : s?.free ?? 0);
@@ -87,6 +89,7 @@ export default function BookingPanel({
   handlePay,
   handleCancel,
   purchaseId,
+  onDownloadTicket,
 }: Props) {
   const [activeLeg, setActiveLeg] = useState<"outbound" | "return">("outbound");
 
@@ -212,6 +215,15 @@ export default function BookingPanel({
                 Багаж обратно
               </label>
             )}
+            {purchaseId && (
+              <button
+                type="button"
+                onClick={() => onDownloadTicket(purchaseId)}
+                className="whitespace-nowrap rounded border px-2 py-1 text-sm hover:bg-slate-100"
+              >
+                {t.ticketDownload}
+              </button>
+            )}
           </div>
         ))}
 
@@ -262,6 +274,13 @@ export default function BookingPanel({
                 className="border rounded p-2 hover:bg-slate-100"
               >
                 {t.cancel}
+              </button>
+              <button
+                type="button"
+                onClick={() => onDownloadTicket(purchaseId)}
+                className="border rounded p-2 hover:bg-slate-100"
+              >
+                {t.ticketDownload}
               </button>
             </>
           )}

--- a/src/components/search/ElectronicTicket.tsx
+++ b/src/components/search/ElectronicTicket.tsx
@@ -107,7 +107,7 @@ export default function ElectronicTicket({ ticket, t, onDownload }: Props) {
         <h4 className="font-semibold text-sky-800">{t.ticketPassengers}</h4>
         <div className="mt-2 grid gap-3 md:grid-cols-2">
           {ticket.passengers.map((passenger, index) => (
-            <div key={`${passenger.name}-${index}`} className="rounded-lg border bg-white p-4">
+            <div key={`${passenger.name}-${index}`} className="flex flex-col gap-2 rounded-lg border bg-white p-4">
               <p className="font-semibold text-slate-800">{passenger.name}</p>
               <p className="text-sm text-slate-600">
                 {t.ticketPassengerSeat}: {passenger.seatOutbound ?? "—"}
@@ -125,6 +125,13 @@ export default function ElectronicTicket({ ticket, t, onDownload }: Props) {
                   {t.ticketPassengerBaggageReturn}: {passenger.extraBaggageReturn ? t.ticketYes : t.ticketNo}
                 </p>
               )}
+              <button
+                type="button"
+                onClick={downloadTicket}
+                className="self-start rounded border border-sky-500 px-3 py-1 text-sm text-sky-700 transition hover:bg-sky-500 hover:text-white"
+              >
+                {t.ticketDownload}
+              </button>
             </div>
           ))}
         </div>

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -648,13 +648,16 @@ export default function SearchResults({
     }
   };
 
-  const handleTicketDownload = async () => {
-    if (!ticket) {
+  const handleTicketDownload = async (purchaseIdOverride?: number) => {
+    const targetPurchaseId = purchaseIdOverride ?? ticket?.purchaseId;
+    if (!targetPurchaseId) {
       return;
     }
 
+    const resolvedLang: NonNullable<Props["lang"]> = lang ?? "ru";
+
     try {
-      await downloadTicketPdf(ticket.purchaseId, lang);
+      await downloadTicketPdf(targetPurchaseId, resolvedLang);
       setShowDownloadPrompt(false);
     } catch (error) {
       console.error(error);
@@ -663,8 +666,8 @@ export default function SearchResults({
     }
   };
 
-  const handleTicketDownloadClick = () => {
-    void handleTicketDownload();
+  const handleTicketDownloadClick = (purchaseIdOverride?: number) => {
+    void handleTicketDownload(purchaseIdOverride);
   };
 
   const handlePromptClose = () => {
@@ -717,47 +720,48 @@ export default function SearchResults({
       {/* ВЫБОР МЕСТ + ФОРМА */}
       {selectedOutboundTour &&
         (!returnDate || (returnDate && selectedReturnTour)) && (
-          <BookingPanel
-            t={t}
-            seatCount={safeSeatCount}
-            fromId={fromId}
-            toId={toId}
-            fromName={fromName}
-            toName={toName}
-            selectedOutboundTour={selectedOutboundTour}
-            selectedReturnTour={selectedReturnTour}
-            selectedOutboundSeats={selectedOutboundSeats}
-            setSelectedOutboundSeats={setSelectedOutboundSeats}
-            selectedReturnSeats={selectedReturnSeats}
-            setSelectedReturnSeats={setSelectedReturnSeats}
-            passengerNames={passengerNames}
-            setPassengerNames={setPassengerNames}
-            phone={phone}
-            setPhone={setPhone}
-            email={email}
-            setEmail={setEmail}
-            extraBaggageOutbound={extraBaggageOutbound}
-            setExtraBaggageOutbound={setExtraBaggageOutbound}
-            extraBaggageReturn={extraBaggageReturn}
-            setExtraBaggageReturn={setExtraBaggageReturn}
-            handleAction={handleAction}
-            handlePay={handlePay}
-            handleCancel={handleCancel}
-            purchaseId={purchaseId}
-          />
-        )}
+        <BookingPanel
+          t={t}
+          seatCount={safeSeatCount}
+          fromId={fromId}
+          toId={toId}
+          fromName={fromName}
+          toName={toName}
+          selectedOutboundTour={selectedOutboundTour}
+          selectedReturnTour={selectedReturnTour}
+          selectedOutboundSeats={selectedOutboundSeats}
+          setSelectedOutboundSeats={setSelectedOutboundSeats}
+          selectedReturnSeats={selectedReturnSeats}
+          setSelectedReturnSeats={setSelectedReturnSeats}
+          passengerNames={passengerNames}
+          setPassengerNames={setPassengerNames}
+          phone={phone}
+          setPhone={setPhone}
+          email={email}
+          setEmail={setEmail}
+          extraBaggageOutbound={extraBaggageOutbound}
+          setExtraBaggageOutbound={setExtraBaggageOutbound}
+          extraBaggageReturn={extraBaggageReturn}
+          setExtraBaggageReturn={setExtraBaggageReturn}
+          handleAction={handleAction}
+          handlePay={handlePay}
+          handleCancel={handleCancel}
+          purchaseId={purchaseId}
+          onDownloadTicket={handleTicketDownloadClick}
+        />
+      )}
 
       {ticket && (
         <ElectronicTicket
           ticket={ticket}
           t={t}
-          onDownload={handleTicketDownloadClick}
+          onDownload={() => handleTicketDownloadClick()}
         />
       )}
       <TicketDownloadPrompt
         visible={showDownloadPrompt && !!ticket}
         t={t}
-        onDownload={handleTicketDownloadClick}
+        onDownload={() => handleTicketDownloadClick()}
         onClose={handlePromptClose}
       />
     </div>


### PR DESCRIPTION
## Summary
- add a PDF download action to the booking panel whenever a purchase is available
- reuse the shared ticket download handler so other views can trigger a PDF export by purchase id
- add per-passenger ticket download buttons in booking and ticket views

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da6541902c8327b880738363762e2c