### PR TITLE
Add automatic scrolling through booking flow steps

### DIFF
--- a/src/components/booking/BookingCard.tsx
+++ b/src/components/booking/BookingCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import SearchForm from "@/components/hero/SearchForm";
 import SearchResults from "@/components/search/SearchResults";
 import { useLanguage } from "@/components/common/LanguageProvider";
@@ -19,12 +19,22 @@ type Criteria = {
 export default function BookingCard() {
   const [criteria, setCriteria] = useState<Criteria | null>(null);
   const { lang } = useLanguage();
+  const resultsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (criteria && resultsRef.current) {
+      resultsRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [criteria]);
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6">
       <SearchForm lang={lang} onSearch={(params) => setCriteria(params)} />
       {criteria && (
-        <div className="rounded-3xl bg-white/20 backdrop-blur p-5 shadow-lg ring-1 ring-white/30">
+        <div
+          ref={resultsRef}
+          className="rounded-3xl bg-white/20 backdrop-blur p-5 shadow-lg ring-1 ring-white/30"
+        >
           <SearchResults lang={lang} {...criteria} />
         </div>
       )}

--- a/src/components/hero/HeroSection.tsx
+++ b/src/components/hero/HeroSection.tsx
@@ -1,7 +1,7 @@
 // src/components/hero/HeroSection.tsx
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import SearchForm from "./SearchForm";
 import SearchResults from "@/components/search/SearchResults";
 import { translations as heroTranslations } from "@/i18n";
@@ -20,7 +20,14 @@ export default function HeroSection({ lang = "ru" }: { lang?: Lang }) {
     discountCount: number;
   }>(null);
 
+  const resultsRef = useRef<HTMLDivElement | null>(null);
   const expanded = !!criteria;
+
+  useEffect(() => {
+    if (criteria && resultsRef.current) {
+      resultsRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [criteria]);
 
   return (
     <section
@@ -55,7 +62,7 @@ export default function HeroSection({ lang = "ru" }: { lang?: Lang }) {
             ].join(' ')}
           >
             {expanded && (
-              <div className="px-5 pb-5 pt-0">
+              <div ref={resultsRef} className="px-5 pb-5 pt-0">
                 <div className="rounded-2xl bg-white/80 p-4 text-slate-900 shadow ring-1 ring-black/5">
                   <SearchResults
                     lang={lang}

--- a/src/components/search/BookingPanel.tsx
+++ b/src/components/search/BookingPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import SeatClient from "../SeatClient";
 import type { Tour } from "./SearchResults";
 import FormInput from "../common/FormInput";
@@ -92,6 +92,23 @@ export default function BookingPanel({
   onDownloadTicket,
 }: Props) {
   const [activeLeg, setActiveLeg] = useState<"outbound" | "return">("outbound");
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const seatsScrollTriggered = useRef(false);
+
+  useEffect(() => {
+    const outboundComplete = selectedOutboundSeats.length === seatCount;
+    const returnComplete =
+      !selectedReturnTour || selectedReturnSeats.length === seatCount;
+
+    if (seatCount > 0 && outboundComplete && returnComplete) {
+      if (!seatsScrollTriggered.current) {
+        seatsScrollTriggered.current = true;
+        formRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    } else {
+      seatsScrollTriggered.current = false;
+    }
+  }, [seatCount, selectedOutboundSeats, selectedReturnSeats, selectedReturnTour]);
 
   return (
     <>
@@ -172,6 +189,7 @@ export default function BookingPanel({
 
       {/* ФОРМА ПАССАЖИРОВ */}
       <form
+        ref={formRef}
         onSubmit={(e) => e.preventDefault()}
         className="mt-5 flex w-full max-w-[440px] flex-col gap-2"
       >

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import axios from "axios";
 
 import Loader from "../common/Loader";
@@ -326,6 +326,14 @@ export default function SearchResults({
   const [ticket, setTicket] = useState<ElectronicTicketData | null>(null);
   const [showDownloadPrompt, setShowDownloadPrompt] = useState(false);
 
+  const outboundSectionRef = useRef<HTMLDivElement | null>(null);
+  const returnSectionRef = useRef<HTMLDivElement | null>(null);
+  const bookingSectionRef = useRef<HTMLDivElement | null>(null);
+
+  const scrollToSection = useCallback((ref: React.RefObject<HTMLElement>) => {
+    ref.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
   // Выбор рейсов
   const [selectedOutboundTour, setSelectedOutboundTour] = useState<Tour | null>(null);
   const [selectedReturnTour, setSelectedReturnTour] = useState<Tour | null>(null);
@@ -436,6 +444,31 @@ export default function SearchResults({
       cancelled = true;
     };
   }, [fromId, toId, date, returnDate, safeSeatCount, t]);
+
+  const hasReturnSection = Boolean(returnDate && returnTours.length > 0);
+
+  useEffect(() => {
+    if (outboundTours.length > 0) {
+      scrollToSection(outboundSectionRef);
+    }
+  }, [outboundTours.length, scrollToSection]);
+
+  useEffect(() => {
+    if (!selectedOutboundTour) {
+      return;
+    }
+    if (hasReturnSection) {
+      scrollToSection(returnSectionRef);
+    } else {
+      scrollToSection(bookingSectionRef);
+    }
+  }, [selectedOutboundTour, hasReturnSection, scrollToSection]);
+
+  useEffect(() => {
+    if (selectedReturnTour) {
+      scrollToSection(bookingSectionRef);
+    }
+  }, [selectedReturnTour, scrollToSection]);
 
   // Выбор рейсов
   const onSelectOutbound = (tour: Tour) => {
@@ -685,70 +718,76 @@ export default function SearchResults({
 
       {/* РЕЙСЫ ТУДА */}
       {outboundTours.length > 0 && (
-        <TripList
-          title={t.outbound}
-          tours={outboundTours}
-          selectedId={selectedOutboundTour?.id}
-          onSelect={onSelectOutbound}
-          freeSeatsValue={freeSeatsValue}
-          fromName={fromName}
-          toName={toName}
-          lang={lang}
-          seatCount={safeSeatCount}
-          discountCount={safeDiscountCount}
-          t={t}
-        />
+        <div ref={outboundSectionRef}>
+          <TripList
+            title={t.outbound}
+            tours={outboundTours}
+            selectedId={selectedOutboundTour?.id}
+            onSelect={onSelectOutbound}
+            freeSeatsValue={freeSeatsValue}
+            fromName={fromName}
+            toName={toName}
+            lang={lang}
+            seatCount={safeSeatCount}
+            discountCount={safeDiscountCount}
+            t={t}
+          />
+        </div>
       )}
 
       {/* РЕЙСЫ ОБРАТНО */}
       {returnDate && returnTours.length > 0 && (
-        <TripList
-          title={t.inbound}
-          tours={returnTours}
-          selectedId={selectedReturnTour?.id}
-          onSelect={onSelectReturn}
-          freeSeatsValue={freeSeatsValue}
-          fromName={toName}
-          toName={fromName}
-          lang={lang}
-          seatCount={safeSeatCount}
-          discountCount={safeDiscountCount}
-          t={t}
-        />
+        <div ref={returnSectionRef}>
+          <TripList
+            title={t.inbound}
+            tours={returnTours}
+            selectedId={selectedReturnTour?.id}
+            onSelect={onSelectReturn}
+            freeSeatsValue={freeSeatsValue}
+            fromName={toName}
+            toName={fromName}
+            lang={lang}
+            seatCount={safeSeatCount}
+            discountCount={safeDiscountCount}
+            t={t}
+          />
+        </div>
       )}
 
       {/* ВЫБОР МЕСТ + ФОРМА */}
       {selectedOutboundTour &&
         (!returnDate || (returnDate && selectedReturnTour)) && (
-        <BookingPanel
-          t={t}
-          seatCount={safeSeatCount}
-          fromId={fromId}
-          toId={toId}
-          fromName={fromName}
-          toName={toName}
-          selectedOutboundTour={selectedOutboundTour}
-          selectedReturnTour={selectedReturnTour}
-          selectedOutboundSeats={selectedOutboundSeats}
-          setSelectedOutboundSeats={setSelectedOutboundSeats}
-          selectedReturnSeats={selectedReturnSeats}
-          setSelectedReturnSeats={setSelectedReturnSeats}
-          passengerNames={passengerNames}
-          setPassengerNames={setPassengerNames}
-          phone={phone}
-          setPhone={setPhone}
-          email={email}
-          setEmail={setEmail}
-          extraBaggageOutbound={extraBaggageOutbound}
-          setExtraBaggageOutbound={setExtraBaggageOutbound}
-          extraBaggageReturn={extraBaggageReturn}
-          setExtraBaggageReturn={setExtraBaggageReturn}
-          handleAction={handleAction}
-          handlePay={handlePay}
-          handleCancel={handleCancel}
-          purchaseId={purchaseId}
-          onDownloadTicket={handleTicketDownloadClick}
-        />
+        <div ref={bookingSectionRef}>
+          <BookingPanel
+            t={t}
+            seatCount={safeSeatCount}
+            fromId={fromId}
+            toId={toId}
+            fromName={fromName}
+            toName={toName}
+            selectedOutboundTour={selectedOutboundTour}
+            selectedReturnTour={selectedReturnTour}
+            selectedOutboundSeats={selectedOutboundSeats}
+            setSelectedOutboundSeats={setSelectedOutboundSeats}
+            selectedReturnSeats={selectedReturnSeats}
+            setSelectedReturnSeats={setSelectedReturnSeats}
+            passengerNames={passengerNames}
+            setPassengerNames={setPassengerNames}
+            phone={phone}
+            setPhone={setPhone}
+            email={email}
+            setEmail={setEmail}
+            extraBaggageOutbound={extraBaggageOutbound}
+            setExtraBaggageOutbound={setExtraBaggageOutbound}
+            extraBaggageReturn={extraBaggageReturn}
+            setExtraBaggageReturn={setExtraBaggageReturn}
+            handleAction={handleAction}
+            handlePay={handlePay}
+            handleCancel={handleCancel}
+            purchaseId={purchaseId}
+            onDownloadTicket={handleTicketDownloadClick}
+          />
+        </div>
       )}
 
       {ticket && (


### PR DESCRIPTION
## Summary
- scroll the search results card into view after submitting booking criteria
- automatically move focus to the next booking step when selecting outbound or return trips
- scroll passengers form into view once the required seats are selected

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da870360c88327a77892bccdddd6f8