### PR TITLE
Fix duplicate passengerCount declaration

### DIFF
--- a/src/components/ticket/TicketClient.tsx
+++ b/src/components/ticket/TicketClient.tsx
@@ -1168,8 +1168,6 @@ export default function TicketClient({ ticketId }: TicketClientProps) {
     );
   }
 
-  const passengerCount = ticket.passengers?.length ?? 0;
-
   return (
     <main className="min-h-screen bg-gradient-to-b from-sky-100 via-white to-slate-100 p-4">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">


### PR DESCRIPTION
## Summary
- remove the duplicate `passengerCount` declaration in `TicketClient` to resolve the module parse error

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbb62f031c8327a904517c300dfb19