### PR TITLE
Update ticket PDF download URL

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -687,10 +687,8 @@ export default function SearchResults({
       return;
     }
 
-    const resolvedLang: NonNullable<Props["lang"]> = lang ?? "ru";
-
     try {
-      await downloadTicketPdf(targetPurchaseId, resolvedLang);
+      await downloadTicketPdf(targetPurchaseId);
       setShowDownloadPrompt(false);
     } catch (error) {
       console.error(error);

--- a/src/utils/ticketPdf.ts
+++ b/src/utils/ticketPdf.ts
@@ -1,23 +1,18 @@
 import { API } from "@/config";
 
-type SupportedLang = "ru" | "bg" | "en" | "ua";
-
-const buildTicketPdfUrl = (purchaseId: number, lang: SupportedLang): string => {
+const buildTicketPdfUrl = (purchaseId: number): string => {
   const url = new URL(`${API}/tickets/${purchaseId}/pdf`);
   url.hostname = "127.0.0.1";
-  url.searchParams.set("lang", lang);
+  url.search = "";
   return url.toString();
 };
 
-export const downloadTicketPdf = async (
-  purchaseId: number,
-  lang: SupportedLang
-): Promise<void> => {
+export const downloadTicketPdf = async (purchaseId: number): Promise<void> => {
   if (typeof window === "undefined") {
     return;
   }
 
-  const pdfUrl = buildTicketPdfUrl(purchaseId, lang);
+  const pdfUrl = buildTicketPdfUrl(purchaseId);
   const response = await fetch(pdfUrl, {
     method: "GET",
     headers: { Accept: "application/pdf" },


### PR DESCRIPTION
## Summary
- remove the language query parameter when building the ticket PDF URL
- update the ticket download handler to use the simplified helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd9d057cc8327bae35c461f3ce755