### PR TITLE
Use ticket number for ticket PDF download

### DIFF
--- a/src/components/search/BookingPanel.tsx
+++ b/src/components/search/BookingPanel.tsx
@@ -53,7 +53,8 @@ type Props = {
   handlePay: () => void;
   handleCancel: () => void;
   purchaseId: number | null;
-  onDownloadTicket: (purchaseId: number) => void;
+  ticketNumber: string | null;
+  onDownloadTicket: () => void;
 };
 
 const free = (s: Tour["seats"]) => (typeof s === "number" ? s : s?.free ?? 0);
@@ -89,11 +90,13 @@ export default function BookingPanel({
   handlePay,
   handleCancel,
   purchaseId,
+  ticketNumber,
   onDownloadTicket,
 }: Props) {
   const [activeLeg, setActiveLeg] = useState<"outbound" | "return">("outbound");
   const formRef = useRef<HTMLFormElement | null>(null);
   const seatsScrollTriggered = useRef(false);
+  const hasTicketIdentifier = Boolean(ticketNumber ?? purchaseId);
 
   useEffect(() => {
     const outboundComplete = selectedOutboundSeats.length === seatCount;
@@ -233,10 +236,10 @@ export default function BookingPanel({
                 Багаж обратно
               </label>
             )}
-            {purchaseId && (
+            {hasTicketIdentifier && (
               <button
                 type="button"
-                onClick={() => onDownloadTicket(purchaseId)}
+                onClick={onDownloadTicket}
                 className="whitespace-nowrap rounded border px-2 py-1 text-sm hover:bg-slate-100"
               >
                 {t.ticketDownload}
@@ -293,13 +296,15 @@ export default function BookingPanel({
               >
                 {t.cancel}
               </button>
-              <button
-                type="button"
-                onClick={() => onDownloadTicket(purchaseId)}
-                className="border rounded p-2 hover:bg-slate-100"
-              >
-                {t.ticketDownload}
-              </button>
+              {hasTicketIdentifier && (
+                <button
+                  type="button"
+                  onClick={onDownloadTicket}
+                  className="border rounded p-2 hover:bg-slate-100"
+                >
+                  {t.ticketDownload}
+                </button>
+              )}
             </>
           )}
         </div>

--- a/src/components/search/ElectronicTicket.tsx
+++ b/src/components/search/ElectronicTicket.tsx
@@ -82,7 +82,7 @@ export default function ElectronicTicket({ ticket, t, onDownload }: Props) {
         <div>
           <h3 className="text-xl font-semibold text-sky-900">{t.ticketTitle}</h3>
           <p className="text-sm text-slate-600">
-            {t.ticketNumber}: {ticket.purchaseId}
+            {t.ticketNumber}: {ticket.ticketNumber ?? ticket.purchaseId}
           </p>
         </div>
         <button

--- a/src/types/ticket.ts
+++ b/src/types/ticket.ts
@@ -20,6 +20,7 @@ export type ElectronicTicketPassenger = {
 
 export type ElectronicTicketData = {
   purchaseId: number;
+  ticketNumber: string | null;
   action: "book" | "purchase";
   total: number;
   createdAt: string;

--- a/src/utils/ticketPdf.ts
+++ b/src/utils/ticketPdf.ts
@@ -1,23 +1,20 @@
 import { API } from "@/config";
 
-type SupportedLang = "ru" | "bg" | "en" | "ua";
-
-const buildTicketPdfUrl = (purchaseId: number, lang: SupportedLang): string => {
-  const url = new URL(`${API}/tickets/${purchaseId}/pdf`);
+const buildTicketPdfUrl = (ticketNumber: string | number): string => {
+  const url = new URL(`${API}/tickets/${ticketNumber}/pdf`);
   url.hostname = "127.0.0.1";
-  url.searchParams.set("lang", lang);
+  url.search = "";
   return url.toString();
 };
 
 export const downloadTicketPdf = async (
-  purchaseId: number,
-  lang: SupportedLang
+  ticketNumber: string | number
 ): Promise<void> => {
   if (typeof window === "undefined") {
     return;
   }
 
-  const pdfUrl = buildTicketPdfUrl(purchaseId, lang);
+  const pdfUrl = buildTicketPdfUrl(ticketNumber);
   const response = await fetch(pdfUrl, {
     method: "GET",
     headers: { Accept: "application/pdf" },
@@ -33,7 +30,7 @@ export const downloadTicketPdf = async (
 
   const link = document.createElement("a");
   link.href = objectUrl;
-  link.download = `ticket-${purchaseId}.pdf`;
+  link.download = `ticket-${ticketNumber}.pdf`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);


### PR DESCRIPTION
## Summary
- extract ticket numbers from booking responses and store them on the ticket model
- request ticket PDFs by ticket number across search results, booking panel, and download helper
- update the electronic ticket display to show the ticket number while retaining purchase actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd9d057cc8327bae35c461f3ce755