### PR TITLE
Switch ticket download to ticket number

### DIFF
--- a/src/components/search/BookingPanel.tsx
+++ b/src/components/search/BookingPanel.tsx
@@ -53,7 +53,8 @@ type Props = {
   handlePay: () => void;
   handleCancel: () => void;
   purchaseId: number | null;
-  onDownloadTicket: (purchaseId: number) => void;
+  ticketNumber: string | null;
+  onDownloadTicket: (ticketNumber: string) => void;
 };
 
 const free = (s: Tour["seats"]) => (typeof s === "number" ? s : s?.free ?? 0);
@@ -89,6 +90,7 @@ export default function BookingPanel({
   handlePay,
   handleCancel,
   purchaseId,
+  ticketNumber,
   onDownloadTicket,
 }: Props) {
   const [activeLeg, setActiveLeg] = useState<"outbound" | "return">("outbound");
@@ -233,10 +235,10 @@ export default function BookingPanel({
                 Багаж обратно
               </label>
             )}
-            {purchaseId && (
+            {ticketNumber && (
               <button
                 type="button"
-                onClick={() => onDownloadTicket(purchaseId)}
+                onClick={() => onDownloadTicket(ticketNumber)}
                 className="whitespace-nowrap rounded border px-2 py-1 text-sm hover:bg-slate-100"
               >
                 {t.ticketDownload}
@@ -293,14 +295,16 @@ export default function BookingPanel({
               >
                 {t.cancel}
               </button>
-              <button
-                type="button"
-                onClick={() => onDownloadTicket(purchaseId)}
-                className="border rounded p-2 hover:bg-slate-100"
-              >
-                {t.ticketDownload}
-              </button>
             </>
+          )}
+          {ticketNumber && (
+            <button
+              type="button"
+              onClick={() => onDownloadTicket(ticketNumber)}
+              className="border rounded p-2 hover:bg-slate-100"
+            >
+              {t.ticketDownload}
+            </button>
           )}
         </div>
       </form>

--- a/src/components/search/ElectronicTicket.tsx
+++ b/src/components/search/ElectronicTicket.tsx
@@ -82,7 +82,7 @@ export default function ElectronicTicket({ ticket, t, onDownload }: Props) {
         <div>
           <h3 className="text-xl font-semibold text-sky-900">{t.ticketTitle}</h3>
           <p className="text-sm text-slate-600">
-            {t.ticketNumber}: {ticket.purchaseId}
+            {t.ticketNumber}: {ticket.ticketNumber}
           </p>
         </div>
         <button

--- a/src/types/ticket.ts
+++ b/src/types/ticket.ts
@@ -19,6 +19,7 @@ export type ElectronicTicketPassenger = {
 };
 
 export type ElectronicTicketData = {
+  ticketNumber: string;
   purchaseId: number;
   action: "book" | "purchase";
   total: number;

--- a/src/utils/ticketPdf.ts
+++ b/src/utils/ticketPdf.ts
@@ -1,18 +1,20 @@
 import { API } from "@/config";
 
-const buildTicketPdfUrl = (purchaseId: number): string => {
-  const url = new URL(`${API}/tickets/${purchaseId}/pdf`);
+const buildTicketPdfUrl = (ticketNumber: string | number): string => {
+  const url = new URL(`${API}/tickets/${ticketNumber}/pdf`);
   url.hostname = "127.0.0.1";
   url.search = "";
   return url.toString();
 };
 
-export const downloadTicketPdf = async (purchaseId: number): Promise<void> => {
+export const downloadTicketPdf = async (
+  ticketNumber: string | number
+): Promise<void> => {
   if (typeof window === "undefined") {
     return;
   }
 
-  const pdfUrl = buildTicketPdfUrl(purchaseId);
+  const pdfUrl = buildTicketPdfUrl(ticketNumber);
   const response = await fetch(pdfUrl, {
     method: "GET",
     headers: { Accept: "application/pdf" },
@@ -28,7 +30,7 @@ export const downloadTicketPdf = async (purchaseId: number): Promise<void> => {
 
   const link = document.createElement("a");
   link.href = objectUrl;
-  link.download = `ticket-${purchaseId}.pdf`;
+  link.download = `ticket-${ticketNumber}.pdf`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);


### PR DESCRIPTION
## Summary
- derive and persist ticket numbers from booking responses so download requests use ticket IDs
- update booking panel and electronic ticket UI to surface the ticket number and trigger downloads with it
- adjust the ticket PDF helper to accept ticket identifiers instead of purchase IDs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbe1d99f5c83278132aa22144e925d