### PR TITLE
Fix ticket PDF download by reading ticket ID

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -543,6 +543,7 @@ export default function SearchResults({
         if (typeof value === "object") {
           const obj = value as Record<string, unknown>;
           return (
+            coerceTicketNumber(obj["ticket_id"]) ??
             coerceTicketNumber(obj["ticket_number"]) ??
             coerceTicketNumber(obj["ticketNumber"]) ??
             coerceTicketNumber(obj["number"]) ??


### PR DESCRIPTION
## Summary
- ensure ticket number extraction also reads `ticket_id` fields so we request the PDF with the correct identifier

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfb61c4650832787d7f08d5b1f750b