### PR TITLE
feat(routes): collapse long stop lists with expand/collapse toggle

### DIFF
--- a/src/components/Routes.module.css
+++ b/src/components/Routes.module.css
@@ -91,10 +91,31 @@
   font-weight: 700;
 }
 
+.routeCardStopsWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .routeCardStops {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.routeStopsToggle {
+  align-self: flex-start;
+  border: none;
+  background: transparent;
+  color: #0f172a;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.routeStopsToggle:hover {
+  text-decoration: underline;
 }
 
 .routeStop {

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -196,17 +196,35 @@ function RoutePanel({
 }
 
 function StopsList({ stops, lang = "ru" }: { stops: Stop[]; lang?: Lang }) {
+  const L = routesTranslations[lang];
+  const visibleByDefault = 4;
+  const [expanded, setExpanded] = useState(false);
+  const shouldCollapse = stops.length > visibleByDefault;
+  const visibleStops = shouldCollapse && !expanded ? stops.slice(0, visibleByDefault) : stops;
+
   return (
-    <div className={styles.routeCardStops}>
-      {stops.map((stop, i) => (
-        <StopRow
-          key={`${stop.id}-${i}`}
-          stop={stop}
-          index={i + 1}
-          isLast={i === stops.length - 1}
-          lang={lang}
-        />
-      ))}
+    <div className={styles.routeCardStopsWrap}>
+      <div className={styles.routeCardStops}>
+        {visibleStops.map((stop, i) => (
+          <StopRow
+            key={`${stop.id}-${i}`}
+            stop={stop}
+            index={i + 1}
+            isLast={i === visibleStops.length - 1}
+            lang={lang}
+          />
+        ))}
+      </div>
+      {shouldCollapse && (
+        <button
+          type="button"
+          className={styles.routeStopsToggle}
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+        >
+          {expanded ? L.showLess : L.showAll}
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Long routes with many stops make the routes cards verbose, so show only a small subset by default with an option to expand. 

### Description
- Show only the first 4 stops by default and add a local `expanded` state to toggle full/partial view in `StopsList` (`src/components/Routes.tsx`).
- Compute `visibleStops` and render stop numbering and connector line relative to the visible list so UI remains correct when collapsed or expanded. 
- Reuse existing translation keys `showAll` / `showLess` for the toggle label via `routesTranslations`. 
- Add layout and toggle styles (`routeCardStopsWrap`, `routeStopsToggle`) in `src/components/Routes.module.css`.

### Testing
- Ran `npm test`, which executed the TypeScript build and unit tests and all tests passed. 
- Attempted `npm run lint`, which failed in this environment due to an existing project script/config issue (`Invalid project directory provided, no such directory: /workspace/mt-client/lint`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6148374083278fc18e96d30088d0)