### PR TITLE
Add fiscal receipt polling and UI to return page

### DIFF
--- a/src/app/(site)/return/page.tsx
+++ b/src/app/(site)/return/page.tsx
@@ -15,6 +15,8 @@ import type { Lang } from "@/components/common/LanguageProvider";
 
 // ========== Types ==========
 
+type FiscalStatus = "pending" | "processing" | "done" | "failed" | null;
+
 type ResolvePayload = {
   paid?: boolean;
   status?: string;
@@ -26,6 +28,9 @@ type ResolvePayload = {
     id?: string | number | null;
     opaque?: string | null;
   } | null;
+  fiscal_status?: FiscalStatus | string | null;
+  fiscal_receipt_url?: string | null;
+  checkbox_fiscal_code?: string | null;
 };
 
 type PageState =
@@ -245,16 +250,25 @@ function PaidView({
   purchaseView,
   purchaseId,
   lang,
+  orderId,
 }: {
   purchaseView: PurchaseView;
   purchaseId: string;
   lang: Lang;
+  orderId: string;
 }) {
   const t = returnTranslations[lang];
   const locale = dateLocaleMap[lang];
 
   const [isDownloadingAll, setIsDownloadingAll] = useState(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [fiscalStatus, setFiscalStatus] = useState<FiscalStatus>(null);
+  const [fiscalReceiptUrl, setFiscalReceiptUrl] = useState<string | null>(null);
+  const [fiscalError, setFiscalError] = useState<string | null>(null);
+  const [isFiscalPolling, setIsFiscalPolling] = useState(false);
+  const [fiscalPollingAttempts, setFiscalPollingAttempts] = useState(0);
+  const [fiscalPollingTimedOut, setFiscalPollingTimedOut] = useState(false);
+  const [fiscalPublishingAttempts, setFiscalPublishingAttempts] = useState(0);
 
   const tickets = Array.isArray(purchaseView.tickets) ? purchaseView.tickets : [];
   const passengers = Array.isArray(purchaseView.passengers) ? purchaseView.passengers : [];
@@ -383,6 +397,90 @@ function PaidView({
   };
 
   const isRoundTrip = ticketGroups.some((g: TicketGroup) => g.direction === "return");
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    const startedAt = Date.now();
+
+    const fetchPaymentState = async (manual = false) => {
+      if (!orderId) return;
+      if (!manual) setIsFiscalPolling(true);
+      setFiscalPollingAttempts((prev) => prev + 1);
+      try {
+        const params = new URLSearchParams({ order_id: orderId });
+        const response = await fetchWithInclude(`${API}/public/payments/resolve?${params.toString()}`, { method: "GET", cache: "no-store" });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const payload = (await response.json()) as ResolvePayload;
+        const nextStatus = (payload.fiscal_status ?? null) as FiscalStatus;
+        const nextUrl = payload.fiscal_receipt_url?.trim() ? payload.fiscal_receipt_url.trim() : null;
+        if (cancelled) return;
+        setFiscalStatus(nextStatus);
+        setFiscalReceiptUrl(nextUrl);
+        setFiscalError(null);
+
+        if (nextStatus === "failed") {
+          setIsFiscalPolling(false);
+          if (intervalId) clearInterval(intervalId);
+          return;
+        }
+
+        if (nextStatus === "done" && nextUrl) {
+          setIsFiscalPolling(false);
+          if (intervalId) clearInterval(intervalId);
+          return;
+        }
+
+        if (nextStatus === "done" && !nextUrl) {
+          setFiscalPublishingAttempts((prev) => {
+            const next = prev + 1;
+            if (next >= 3 && intervalId) {
+              clearInterval(intervalId);
+              setIsFiscalPolling(false);
+            }
+            return next;
+          });
+        } else {
+          setFiscalPublishingAttempts(0);
+        }
+      } catch {
+        if (cancelled) return;
+        setFiscalError(t.fiscalReceiptSoftError);
+      }
+
+      if (Date.now() - startedAt >= 90000) {
+        setFiscalPollingTimedOut(true);
+        setIsFiscalPolling(false);
+        if (intervalId) clearInterval(intervalId);
+      }
+    };
+
+    void fetchPaymentState();
+    intervalId = setInterval(() => {
+      void fetchPaymentState();
+    }, 5000);
+
+    return () => {
+      cancelled = true;
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [orderId, t.fiscalReceiptSoftError]);
+
+  const retryFiscalCheck = async () => {
+    setFiscalPollingTimedOut(false);
+    setFiscalError(null);
+    setFiscalPublishingAttempts(0);
+    try {
+      const params = new URLSearchParams({ order_id: orderId });
+      const response = await fetchWithInclude(`${API}/public/payments/resolve?${params.toString()}`, { method: "GET", cache: "no-store" });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const payload = (await response.json()) as ResolvePayload;
+      setFiscalStatus((payload.fiscal_status ?? null) as FiscalStatus);
+      setFiscalReceiptUrl(payload.fiscal_receipt_url?.trim() ? payload.fiscal_receipt_url.trim() : null);
+    } catch {
+      setFiscalError(t.fiscalReceiptSoftError);
+    }
+  };
+
 
   return (
     <main className="mx-auto w-full max-w-2xl space-y-6 px-4 py-10">
@@ -447,6 +545,42 @@ function PaidView({
           <TicketGroupCard key={`${group.direction}-${idx}`} group={group} lang={lang} />
         ))}
       </div>
+
+      {/* Fiscal receipt */}
+      {fiscalStatus !== null && (
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm space-y-3">
+          <h2 className="text-base font-semibold text-slate-900">{t.fiscalReceiptTitle}</h2>
+          {(fiscalStatus === "pending" || fiscalStatus === "processing") && (
+            <div className="flex items-center gap-2 text-slate-600 text-sm">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-sky-200 border-t-sky-600" />
+              <span>{t.fiscalReceiptPending}</span>
+            </div>
+          )}
+          {fiscalStatus === "done" && fiscalReceiptUrl && (
+            <div className="space-y-2 text-sm">
+              <p className="text-emerald-700">{t.fiscalReceiptReady}</p>
+              <a href={fiscalReceiptUrl} target="_blank" rel="noopener noreferrer" className="inline-flex rounded-full bg-slate-900 px-4 py-2 text-white font-semibold hover:bg-slate-700 transition">{t.fiscalReceiptOpen}</a>
+            </div>
+          )}
+          {fiscalStatus === "done" && !fiscalReceiptUrl && (
+            <p className="text-sm text-slate-600">{t.fiscalReceiptPublishing}</p>
+          )}
+          {fiscalStatus === "failed" && (
+            <div className="space-y-2 text-sm">
+              <p className="text-red-600">{t.fiscalReceiptFailed}</p>
+              <button type="button" onClick={retryFiscalCheck} className="inline-flex rounded-full bg-slate-900 px-4 py-2 text-white font-semibold hover:bg-slate-700 transition">{t.fiscalReceiptRetry}</button>
+            </div>
+          )}
+          {fiscalPollingTimedOut && fiscalStatus !== "done" && fiscalStatus !== "failed" && (
+            <div className="space-y-2 text-sm">
+              <p className="text-amber-700">{t.fiscalReceiptTimeout}</p>
+              <button type="button" onClick={retryFiscalCheck} className="inline-flex rounded-full bg-slate-900 px-4 py-2 text-white font-semibold hover:bg-slate-700 transition">{t.fiscalReceiptRetry}</button>
+            </div>
+          )}
+          {fiscalError && <p className="text-xs text-amber-700">{fiscalError}</p>}
+          {isFiscalPolling && <p className="text-xs text-slate-400">{t.attemptCounter(fiscalPollingAttempts, 18)}</p>}
+        </div>
+      )}
 
       {/* Download all button */}
       <div className="flex flex-col items-center gap-2">
@@ -731,6 +865,7 @@ function ReturnPageContent() {
         purchaseView={pageState.purchaseView}
         purchaseId={pageState.purchaseId}
         lang={lang}
+        orderId={orderId}
       />
     );
   }

--- a/src/translations/return.ts
+++ b/src/translations/return.ts
@@ -47,6 +47,16 @@ type ReturnPageCopy = {
 
   goHome: string;
   retryPayment: string;
+
+  fiscalReceiptTitle: string;
+  fiscalReceiptPending: string;
+  fiscalReceiptReady: string;
+  fiscalReceiptOpen: string;
+  fiscalReceiptFailed: string;
+  fiscalReceiptRetry: string;
+  fiscalReceiptTimeout: string;
+  fiscalReceiptSoftError: string;
+  fiscalReceiptPublishing: string;
 };
 
 function slavicPlural(n: number, one: string, few: string, many: string): string {
@@ -101,6 +111,16 @@ export const returnTranslations: Record<Lang, ReturnPageCopy> = {
 
     goHome: "На главную",
     retryPayment: "Вернуться к оформлению",
+
+    fiscalReceiptTitle: "Фискальный чек",
+    fiscalReceiptPending: "Чек формируется, подождите…",
+    fiscalReceiptReady: "Чек готов",
+    fiscalReceiptOpen: "Открыть чек",
+    fiscalReceiptFailed: "Не удалось сформировать чек. Попробуйте обновить статус позже.",
+    fiscalReceiptRetry: "Проверить снова",
+    fiscalReceiptTimeout: "Чек может появиться чуть позже",
+    fiscalReceiptSoftError: "Не удалось обновить статус чека. Повторим автоматически.",
+    fiscalReceiptPublishing: "Чек готовится к публикации, попробуйте через несколько секунд",
   },
 
   en: {
@@ -145,6 +165,16 @@ export const returnTranslations: Record<Lang, ReturnPageCopy> = {
 
     goHome: "Go to home page",
     retryPayment: "Back to checkout",
+
+    fiscalReceiptTitle: "Fiscal receipt",
+    fiscalReceiptPending: "Receipt is being generated, please wait…",
+    fiscalReceiptReady: "Receipt is ready",
+    fiscalReceiptOpen: "Open receipt",
+    fiscalReceiptFailed: "Could not generate receipt. Please try checking again later.",
+    fiscalReceiptRetry: "Check again",
+    fiscalReceiptTimeout: "The receipt may appear a little later",
+    fiscalReceiptSoftError: "Could not refresh receipt status. We will retry automatically.",
+    fiscalReceiptPublishing: "Receipt is being published, please try again in a few seconds",
   },
 
   bg: {
@@ -189,6 +219,16 @@ export const returnTranslations: Record<Lang, ReturnPageCopy> = {
 
     goHome: "Към началната страница",
     retryPayment: "Обратно към плащане",
+
+    fiscalReceiptTitle: "Фискален бон",
+    fiscalReceiptPending: "Бонът се генерира, моля изчакайте…",
+    fiscalReceiptReady: "Бонът е готов",
+    fiscalReceiptOpen: "Отвори бона",
+    fiscalReceiptFailed: "Неуспешно генериране на бона. Опитайте да обновите статуса по-късно.",
+    fiscalReceiptRetry: "Провери отново",
+    fiscalReceiptTimeout: "Бонът може да се появи малко по-късно",
+    fiscalReceiptSoftError: "Не успяхме да обновим статуса на бона. Ще опитаме автоматично отново.",
+    fiscalReceiptPublishing: "Бонът се подготвя за публикуване, опитайте след няколко секунди",
   },
 
   ua: {
@@ -233,5 +273,15 @@ export const returnTranslations: Record<Lang, ReturnPageCopy> = {
 
     goHome: "На головну",
     retryPayment: "Повернутися до оформлення",
+
+    fiscalReceiptTitle: "Фіскальний чек",
+    fiscalReceiptPending: "Чек формується, зачекайте…",
+    fiscalReceiptReady: "Чек готовий",
+    fiscalReceiptOpen: "Відкрити чек",
+    fiscalReceiptFailed: "Не вдалося сформувати чек. Спробуйте оновити статус пізніше.",
+    fiscalReceiptRetry: "Перевірити знову",
+    fiscalReceiptTimeout: "Чек може з’явитися трохи пізніше",
+    fiscalReceiptSoftError: "Не вдалося оновити статус чека. Повторимо автоматично.",
+    fiscalReceiptPublishing: "Чек готується до публікації, спробуйте за кілька секунд",
   },
 };


### PR DESCRIPTION
### Motivation

- Provide end users with visibility into fiscal receipt generation after a successful payment and offer a way to retry status checks. 
- Query the backend `payments/resolve` endpoint for fiscal status to surface receipt URL or error state in the paid return flow.

### Description

- Added `FiscalStatus` and extended `ResolvePayload` with `fiscal_status`, `fiscal_receipt_url`, and `checkbox_fiscal_code` fields, and threaded `orderId` into the paid view props. 
- Implemented polling logic in `PaidView` that calls `${API}/public/payments/resolve?order_id=...` to update `fiscalStatus`, `fiscalReceiptUrl`, error state, timeouts and limited publish retries, and exposed a `retryFiscalCheck` action. 
- Rendered a new fiscal receipt UI block in the paid flow reflecting states (`pending`, `processing`, `done`, `failed`, timeout) with actions to open the receipt or retry checks. 
- Added translations for the fiscal receipt copy in `src/translations/return.ts` for all supported languages.

### Testing

- Ran TypeScript type checking and a local Next build to validate types and compile-time errors, which completed successfully. 
- Ran the repository ESLint checks and formatting checks which reported no new issues. 
- No changes were made to existing automated unit tests; existing test suites were not modified by this PR and remained green locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c536cb388327b797f512f0c3e3f7)