### PR TITLE
Add Google Analytics tracking to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,10 @@
 import "./globals.css";
 import type { ReactNode } from "react";
+import Script from "next/script";
 
 import { LanguageProvider } from "@/components/common/LanguageProvider";
+
+const GA_MEASUREMENT_ID = "G-N3PVQB5J6S";
 
 export const metadata = {
   title: "Максимов Турc",
@@ -14,6 +17,20 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ru">
+      <head>
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}');
+          `}
+        </Script>
+      </head>
       <body className="min-h-screen antialiased bg-slate-50 text-slate-900">
         <LanguageProvider>{children}</LanguageProvider>
       </body>


### PR DESCRIPTION
## Summary
Integrated Google Analytics (GA4) into the application by adding tracking scripts to the root layout component.

## Key Changes
- Added Google Analytics measurement ID constant (`GA_MEASUREMENT_ID = "G-N3PVQB5J6S"`)
- Imported Next.js `Script` component for proper script handling
- Added two Google Analytics scripts to the document `<head>`:
  - Google Tag Manager script tag with `afterInteractive` strategy
  - Inline initialization script that configures GA4 with the measurement ID

## Implementation Details
- Used Next.js `Script` component with `afterInteractive` strategy to ensure scripts load after the page becomes interactive, avoiding blocking page rendering
- Placed scripts in the `<head>` section of the root layout to ensure they're loaded globally across all pages
- Used template literals to inject the measurement ID into both the script source URL and the configuration call

https://claude.ai/code/session_01PJQPfqa9nSrFUB9AihGvCA