### PR TITLE
Add GA4 and conversion event tracking for contacts, forms and purchases

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import "./globals.css";
 import type { ReactNode } from "react";
+import Script from "next/script";
 
 import { LanguageProvider } from "@/components/common/LanguageProvider";
+const GA_MEASUREMENT_ID = "G-N3PVQB5J6S";
 
 export const metadata = {
   title: "Максимов Турc",
@@ -14,6 +16,20 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ru">
+      <head>
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="ga4-init" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}');
+          `}
+        </Script>
+      </head>
       <body className="min-h-screen antialiased bg-slate-50 text-slate-900">
         <LanguageProvider>{children}</LanguageProvider>
       </body>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -144,6 +144,14 @@ export default function Header() {
     return `tg://resolve?phone=${digits}`;
   };
 
+  const trackContactClick = (phone: string) => {
+    if (method === "call") {
+      window.gtag?.("event", "phone_click", { event_category: "conversion", event_label: phone });
+      return;
+    }
+    window.gtag?.("event", "messenger_click", { event_category: "conversion", event_label: method });
+  };
+
   return (
     <header className="bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70 sticky top-0 z-30 border-b border-slate-200">
       <nav className="container mx-auto flex max-w-6xl flex-nowrap items-center gap-2 px-4 py-2 md:h-14 md:gap-3">
@@ -336,6 +344,7 @@ export default function Header() {
                     </div>
                     <a
                       href={linkFor(entry.phone)}
+                      onClick={() => trackContactClick(entry.phone)}
                       aria-label={`${actionLabel[method]} ${entry.phone}`}
                       title={actionLabel[method]}
                       className="inline-flex h-9 w-9 items-center justify-center rounded-[14px] border border-slate-200 bg-slate-50 text-slate-700 transition hover:-translate-y-0.5 hover:shadow-md"

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -51,6 +51,14 @@ export default function SiteFooter() {
       )}`
     : "";
 
+  const trackPhoneClick = (phone: string) => {
+    window.gtag?.("event", "phone_click", { event_category: "conversion", event_label: phone });
+  };
+
+  const trackEmailClick = (email: string) => {
+    window.gtag?.("event", "email_click", { event_category: "conversion", event_label: email });
+  };
+
   return (
     <footer className="bg-slate-900 py-10 text-slate-100">
       <div className="container mx-auto grid gap-8 px-4 text-sm md:grid-cols-3">
@@ -63,17 +71,17 @@ export default function SiteFooter() {
           <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-200">{t.contacts}</h3>
           <ul className="space-y-2 text-slate-300">
             <li>
-              <a className="transition hover:text-white hover:underline" href="tel:+380930004636">
+              <a className="transition hover:text-white hover:underline" href="tel:+380930004636" onClick={() => trackPhoneClick("+380930004636")}>
                 +380930004636
               </a>
             </li>
             <li>
-              <a className="transition hover:text-white hover:underline" href="tel:+359894290356">
+              <a className="transition hover:text-white hover:underline" href="tel:+359894290356" onClick={() => trackPhoneClick("+359894290356")}>
                 +359894290356
               </a>
             </li>
             <li>
-              <a className="transition hover:text-white hover:underline" href="mailto:Avroraiko@gmail.com">
+              <a className="transition hover:text-white hover:underline" href="mailto:Avroraiko@gmail.com" onClick={() => trackEmailClick("Avroraiko@gmail.com")}>
                 Avroraiko@gmail.com
               </a>
             </li>

--- a/src/components/about/AboutSection.tsx
+++ b/src/components/about/AboutSection.tsx
@@ -40,6 +40,12 @@ export default function AboutSection({
   const buildViberLink = (phone: string) =>
     `viber://chat?number=%2B${formatPhoneDigits(phone)}`;
   const buildTelegramLink = (phone: string) => `https://t.me/+${formatPhoneDigits(phone)}`;
+  const trackPhoneClick = (phone: string) => {
+    window.gtag?.("event", "phone_click", { event_category: "conversion", event_label: phone });
+  };
+  const trackMessengerClick = (messenger: "whatsapp" | "viber" | "telegram") => {
+    window.gtag?.("event", "messenger_click", { event_category: "conversion", event_label: messenger });
+  };
 
   useEffect(() => {
     setActiveMediaIndex(0);
@@ -153,12 +159,14 @@ export default function AboutSection({
                             <div className="flex flex-wrap items-center justify-between gap-2">
                               <a
                                 href={`tel:${phone}`}
+                                onClick={() => trackPhoneClick(phone)}
                                 className="text-sm font-semibold text-slate-800 hover:text-orange-600"
                               >
                                 {phone}
                               </a>
                               <a
                                 href={`tel:${phone}`}
+                                onClick={() => trackPhoneClick(phone)}
                                 className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-bold uppercase tracking-wide text-slate-700"
                               >
                                 Позвонить
@@ -171,6 +179,7 @@ export default function AboutSection({
                               <div className="flex items-center gap-2">
                                 <a
                                   href={buildViberLink(phone)}
+                                  onClick={() => trackMessengerClick("viber")}
                                   className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-purple-200 bg-white text-purple-700 transition hover:border-purple-400"
                                   target="_blank"
                                   rel="noreferrer"
@@ -186,6 +195,7 @@ export default function AboutSection({
                                 </a>
                                 <a
                                   href={buildWhatsAppLink(phone)}
+                                  onClick={() => trackMessengerClick("whatsapp")}
                                   className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-emerald-200 bg-white text-emerald-700 transition hover:border-emerald-400"
                                   target="_blank"
                                   rel="noreferrer"
@@ -201,6 +211,7 @@ export default function AboutSection({
                                 </a>
                                 <a
                                   href={buildTelegramLink(phone)}
+                                  onClick={() => trackMessengerClick("telegram")}
                                   className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-sky-200 bg-white text-sky-700 transition hover:border-sky-400"
                                   target="_blank"
                                   rel="noreferrer"

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -196,6 +196,10 @@ export default function SearchForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    window.gtag?.("event", "form_submit", {
+      event_category: "conversion",
+      event_label: window.location.pathname,
+    });
     if (!fromId || !toId || !departDate) return;
     const fromName =
       departureStops.find((s) => s.id === fromId)?.stop_name || '';

--- a/src/components/purchase/PurchaseClient.tsx
+++ b/src/components/purchase/PurchaseClient.tsx
@@ -2493,6 +2493,12 @@ export default function PurchaseClient({ purchaseId }: PurchaseClientProps) {
   };
 
   const cancelButtonDisabled = isActionDisabled || cancelSelectionCount === 0;
+  const trackPhoneClick = (phone: string) => {
+    window.gtag?.("event", "phone_click", { event_category: "conversion", event_label: phone });
+  };
+  const trackEmailClick = (email: string) => {
+    window.gtag?.("event", "email_click", { event_category: "conversion", event_label: email });
+  };
 
 
   return (
@@ -2513,16 +2519,26 @@ export default function PurchaseClient({ purchaseId }: PurchaseClientProps) {
             <div className={styles.contactWho}>
               <b>{customer?.name ?? "Покупатель не указан"}</b>
               <div className={styles.contactLine}>
-                {customer?.phone ? (
-                  <a className={styles.contactPill} href={`tel:${customer.phone}`}>
-                    📞 {customer.phone}
-                  </a>
-                ) : null}
-                {customer?.email ? (
-                  <a className={styles.contactPill} href={`mailto:${customer.email}`}>
-                    ✉ {customer.email}
-                  </a>
-                ) : null}
+                {customer?.phone
+                  ? (() => {
+                      const phone = customer.phone;
+                      return (
+                        <a className={styles.contactPill} href={`tel:${phone}`} onClick={() => trackPhoneClick(phone)}>
+                          📞 {phone}
+                        </a>
+                      );
+                    })()
+                  : null}
+                {customer?.email
+                  ? (() => {
+                      const email = customer.email;
+                      return (
+                        <a className={styles.contactPill} href={`mailto:${email}`} onClick={() => trackEmailClick(email)}>
+                          ✉ {email}
+                        </a>
+                      );
+                    })()
+                  : null}
                 {!customer?.phone && !customer?.email ? (
                   <span className={styles.contactPlaceholder}>Контакты не указаны</span>
                 ) : null}

--- a/src/components/search/BookingPanel.tsx
+++ b/src/components/search/BookingPanel.tsx
@@ -353,7 +353,13 @@ export default function BookingPanel({
       {renderSeatOverview()}
 
       <form
-        onSubmit={(e) => e.preventDefault()}
+        onSubmit={(e) => {
+          window.gtag?.("event", "form_submit", {
+            event_category: "conversion",
+            event_label: window.location.pathname,
+          });
+          e.preventDefault();
+        }}
         className="mt-2 flex w-full max-w-[640px] flex-col gap-3 rounded-none bg-transparent p-0 shadow-none ring-0 sm:rounded-xl sm:bg-white/70 sm:p-4 sm:shadow-sm sm:ring-1 sm:ring-slate-200"
       >
         <div className="text-base font-semibold text-slate-900">{t.passengersTitle}</div>

--- a/src/components/search/ContactsAndPaymentStep.tsx
+++ b/src/components/search/ContactsAndPaymentStep.tsx
@@ -93,6 +93,12 @@ export default function ContactsAndPaymentStep({
   canPay,
   onDownloadTicket,
 }: Props) {
+  const trackPurchaseClick = () => {
+    window.gtag?.("event", "purchase_click", {
+      event_category: "conversion",
+      event_label: `${fromName} → ${toName}`.trim() || window.location.pathname,
+    });
+  };
   const badgeTone = "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold";
 
   const setBaggageValue = (idx: number, direction: "outbound" | "return", value: boolean) => {
@@ -314,14 +320,20 @@ export default function ContactsAndPaymentStep({
       <div className="flex flex-wrap gap-3">
         <button
           type="button"
-          onClick={() => handleAction("book")}
+          onClick={() => {
+            trackPurchaseClick();
+            handleAction("book");
+          }}
           className="rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-800 shadow-sm transition hover:-translate-y-px hover:border-slate-300 hover:shadow"
         >
           {t.book}
         </button>
         <button
           type="button"
-          onClick={() => handleAction("purchase")}
+          onClick={() => {
+            trackPurchaseClick();
+            handleAction("purchase");
+          }}
           className="rounded-full bg-emerald-600 px-6 py-3 text-sm font-semibold text-white shadow hover:bg-emerald-700"
         >
           {t.buy}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+declare function gtag(...args: any[]): void;


### PR DESCRIPTION
### Motivation

- Integrate Google Analytics 4 to measure conversions and user interactions across the site.
- Track clicks on phone/email/messenger links, form submissions and purchase/book actions for better analytics.

### Description

- Inject GA4 script into the app layout by importing `next/script`, adding `GA_MEASUREMENT_ID`, and initializing `gtag` in the `<head>` of `src/app/layout.tsx`.
- Add `window.gtag?.(...)` tracking calls for contact interactions and messenger links in `Header.tsx`, `SiteFooter.tsx`, `AboutSection.tsx`, and `PurchaseClient.tsx` to report `phone_click`, `email_click`, and `messenger_click` events.
- Track form submissions in `SearchForm.tsx` and `BookingPanel.tsx` with a `form_submit` event and track purchase/book actions in `ContactsAndPaymentStep.tsx` with a `purchase_click` event; event labels use contextual data like pathname or route names.
- Add a `global.d.ts` declaration `declare function gtag(...args: any[]): void;` to satisfy TypeScript and avoid type errors.

### Testing

- Ran TypeScript type check with `tsc --noEmit`, which completed successfully.
- Built the app with `next build`, which completed successfully.
- Ran the project's automated test suite with `yarn test`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f33cc3ac8327be5e8a78de8ae46e)