### PR TITLE
Add HTTPS redirects, legacy URL cleanup, and SEO canonical/hreflang tags

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,53 @@ from = "/api/*"
 to = "http://38.79.154.248/api/:splat"
 status = 200
 force = true
+
+# Force HTTPS
+[[redirects]]
+from = "http://maximovtours.com/*"
+to = "https://maximovtours.com/:splat"
+status = 301
+force = true
+
+[[redirects]]
+from = "http://www.maximovtours.com/*"
+to = "https://maximovtours.com/:splat"
+status = 301
+force = true
+
+# Legacy URL cleanup (301)
+[[redirects]]
+from = "/home"
+to = "/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/home/*"
+to = "/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/shop"
+to = "/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/shop/*"
+to = "/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/cart/yo"
+to = "/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/cart/yo/*"
+to = "/"
+status = 301
+force = true

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -92,6 +92,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ru">
       <head>
+        <link rel="canonical" href="https://maximovtours.com/" />
+        <link rel="alternate" hrefLang="en" href="https://maximovtours.com/en/" />
+        <link rel="alternate" hrefLang="ru" href="https://maximovtours.com/ru/" />
+        <link rel="alternate" hrefLang="uk" href="https://maximovtours.com/uk/" />
+        <link rel="alternate" hrefLang="bg" href="https://maximovtours.com/bg/" />
+        <link rel="alternate" hrefLang="x-default" href="https://maximovtours.com/" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}


### PR DESCRIPTION
## Summary
This PR improves site security, SEO, and URL management by implementing HTTPS enforcement, cleaning up legacy URLs, and adding proper canonical and hreflang tags for multi-language support.

## Key Changes
- **HTTPS Enforcement**: Added redirects to force HTTPS for both `maximovtours.com` and `www.maximovtours.com` domains (301 redirects)
- **Legacy URL Cleanup**: Implemented 301 redirects for deprecated routes:
  - `/home` and `/home/*` → `/`
  - `/shop` and `/shop/*` → `/`
  - `/cart/yo` and `/cart/yo/*` → `/`
- **SEO Improvements**: Added canonical and hreflang tags in the root layout to:
  - Specify canonical URL as `https://maximovtours.com/`
  - Declare language alternatives for English, Russian, Ukrainian, Bulgarian, and default locale

## Implementation Details
- All legacy URL redirects use permanent 301 status codes to preserve SEO value
- Hreflang tags support 5 language variants (en, ru, uk, bg, x-default)
- Canonical tag prevents duplicate content issues across domain variations
- Changes are configured in Netlify's redirect rules and Next.js root layout component

https://claude.ai/code/session_01Lc19fnFvf1qjgSUVGysnPA