### PR TITLE
Replace native selects with fuzzy-searchable inputs in DirectionSelect

### DIFF
--- a/src/components/hero/DirectionSelect.tsx
+++ b/src/components/hero/DirectionSelect.tsx
@@ -8,14 +8,13 @@ type Lang = 'ru' | 'bg' | 'en' | 'ua';
 type Stop = { id: number; stop_name: string };
 
 type Props = {
-  from: string;                        // id отправной
-  to: string;                          // id конечной
+  from: string;
+  to: string;
   setFrom: (v: string) => void;
   setTo: (v: string) => void;
-  seatCount: number;                   // кол-во мест
+  seatCount: number;
   lang?: Lang;
   className?: string;
-  /** если хочешь отследить реверс во внешнем коде */
   onSwap?: () => void;
 };
 
@@ -25,25 +24,81 @@ const T = {
     to: 'Куда',
     swap: 'Поменять направление',
     loading: 'Загрузка…',
+    noResults: 'Ничего не найдено',
   },
   bg: {
     from: 'Откуда',
-    to: 'Куда',
+    to: 'Къде',
     swap: 'Смяна на посоката',
     loading: 'Зареждане…',
+    noResults: 'Няма резултати',
   },
   en: {
     from: 'From',
     to: 'To',
     swap: 'Swap direction',
     loading: 'Loading…',
+    noResults: 'No results',
   },
   ua: {
     from: 'Звідки',
     to: 'Куди',
     swap: 'Поміняти напрям',
     loading: 'Завантаження…',
+    noResults: 'Нічого не знайдено',
   },
+};
+
+const normalize = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim();
+
+const levenshteinDistance = (a: string, b: string) => {
+  if (!a) return b.length;
+  if (!b) return a.length;
+
+  const matrix: number[][] = Array.from({ length: a.length + 1 }, () => []);
+
+  for (let i = 0; i <= a.length; i += 1) matrix[i][0] = i;
+  for (let j = 0; j <= b.length; j += 1) matrix[0][j] = j;
+
+  for (let i = 1; i <= a.length; i += 1) {
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost,
+      );
+    }
+  }
+
+  return matrix[a.length][b.length];
+};
+
+const fuzzyFilterStops = (stops: Stop[], query: string, maxItems = 30) => {
+  const cleanQuery = normalize(query);
+  if (!cleanQuery) return stops.slice(0, maxItems);
+
+  return stops
+    .map((stop) => {
+      const name = normalize(stop.stop_name);
+      const firstWord = name.split(/\s+/)[0] || name;
+      const fullDistance = levenshteinDistance(cleanQuery, name);
+      const firstWordDistance = levenshteinDistance(cleanQuery, firstWord);
+      const containsBonus = name.includes(cleanQuery) ? -1 : 0;
+
+      return {
+        stop,
+        score: Math.min(fullDistance, firstWordDistance) + containsBonus,
+      };
+    })
+    .sort((a, b) => a.score - b.score || a.stop.stop_name.localeCompare(b.stop.stop_name))
+    .slice(0, maxItems)
+    .map(({ stop }) => stop);
 };
 
 export default function DirectionSelect({
@@ -64,11 +119,59 @@ export default function DirectionSelect({
   const [departures, setDepartures] = useState<Stop[]>([]);
   const [arrivals, setArrivals] = useState<Stop[]>([]);
 
-  // refs для авто-перехода фокуса from → to
-  const fromRef = useRef<HTMLSelectElement | null>(null);
-  const toRef = useRef<HTMLSelectElement | null>(null);
+  const [fromQuery, setFromQuery] = useState('');
+  const [toQuery, setToQuery] = useState('');
+  const [fromOpen, setFromOpen] = useState(false);
+  const [toOpen, setToOpen] = useState(false);
 
-  // Загрузка отправных остановок
+  const fromRef = useRef<HTMLInputElement | null>(null);
+  const toRef = useRef<HTMLInputElement | null>(null);
+
+  const sortedDepartures = useMemo(
+    () => [...departures].sort((a, b) => a.stop_name.localeCompare(b.stop_name, lang)),
+    [departures, lang],
+  );
+  const sortedArrivals = useMemo(
+    () => [...arrivals].sort((a, b) => a.stop_name.localeCompare(b.stop_name, lang)),
+    [arrivals, lang],
+  );
+
+  const selectedFromName = useMemo(
+    () => sortedDepartures.find((s) => String(s.id) === from)?.stop_name ?? '',
+    [sortedDepartures, from],
+  );
+  const selectedToName = useMemo(
+    () => sortedArrivals.find((s) => String(s.id) === to)?.stop_name ?? '',
+    [sortedArrivals, to],
+  );
+
+  const prevFromRef = useRef(from);
+  const prevToRef = useRef(to);
+
+  useEffect(() => {
+    if (from && prevFromRef.current !== from) {
+      setFromQuery(selectedFromName);
+    }
+
+    if (!from && prevFromRef.current && fromQuery === selectedFromName) {
+      setFromQuery('');
+    }
+
+    prevFromRef.current = from;
+  }, [from, selectedFromName, fromQuery]);
+
+  useEffect(() => {
+    if (to && prevToRef.current !== to) {
+      setToQuery(selectedToName);
+    }
+
+    if (!to && prevToRef.current && toQuery === selectedToName) {
+      setToQuery('');
+    }
+
+    prevToRef.current = to;
+  }, [to, selectedToName, toQuery]);
+
   useEffect(() => {
     let aborted = false;
     async function load() {
@@ -84,15 +187,16 @@ export default function DirectionSelect({
         const data: Stop[] = await res.json();
         if (!aborted) {
           setDepartures(Array.isArray(data) ? data : []);
-          // если текущего from нет в списке — сбросить
           if (from && !data.some((s) => String(s.id) === String(from))) {
             setFrom('');
+            setFromQuery('');
           }
         }
       } catch (e) {
         if (!aborted) {
           setDepartures([]);
           setFrom('');
+          setFromQuery('');
         }
         console.error('Failed to load departures', e);
       } finally {
@@ -105,13 +209,13 @@ export default function DirectionSelect({
     };
   }, [seatCount, lang]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Загрузка конечных при выборе отправной
   useEffect(() => {
     let aborted = false;
     async function load() {
       if (!from) {
         setArrivals([]);
         if (to) setTo('');
+        setToQuery('');
         return;
       }
       setArrLoading(true);
@@ -119,11 +223,7 @@ export default function DirectionSelect({
         const res = await fetch(`${API}/search/arrivals`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            departure_stop_id: Number(from),
-            seats: seatCount || 1,
-            lang,
-          }),
+          body: JSON.stringify({ departure_stop_id: Number(from), seats: seatCount || 1, lang }),
           cache: 'no-store',
         });
         if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
@@ -132,12 +232,14 @@ export default function DirectionSelect({
           setArrivals(Array.isArray(data) ? data : []);
           if (to && !data.some((s) => String(s.id) === String(to))) {
             setTo('');
+            setToQuery('');
           }
         }
       } catch (e) {
         if (!aborted) {
           setArrivals([]);
           setTo('');
+          setToQuery('');
         }
         console.error('Failed to load arrivals', e);
       } finally {
@@ -151,6 +253,8 @@ export default function DirectionSelect({
   }, [from, seatCount, lang]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const canSwap = useMemo(() => Boolean(from && to), [from, to]);
+  const visibleDepartures = useMemo(() => fuzzyFilterStops(sortedDepartures, fromQuery), [sortedDepartures, fromQuery]);
+  const visibleArrivals = useMemo(() => fuzzyFilterStops(sortedArrivals, toQuery), [sortedArrivals, toQuery]);
 
   const handleSwap = () => {
     if (!canSwap) return;
@@ -163,64 +267,58 @@ export default function DirectionSelect({
 
   return (
     <div className={`flex items-center gap-3 ${className}`}>
-      {/* FROM */}
       <div className="flex-1 min-w-[180px]">
-        <label className="text-white/90 text-sm mb-1 block select-none">
-          {t.from}
-        </label>
+        <label className="text-white/90 text-sm mb-1 block select-none">{t.from}</label>
         <div className="relative">
-          <select
+          <input
             ref={fromRef}
-            className="w-full h-11 px-4 pr-9 bg-white rounded-xl border border-transparent hover:border-blue-300 transition appearance-none text-gray-900"
-            value={from}
+            className="w-full h-11 px-4 pr-9 bg-white rounded-xl border border-transparent hover:border-blue-300 transition text-gray-900"
+            value={fromQuery}
+            placeholder={depLoading ? t.loading : t.from}
+            onFocus={() => setFromOpen(true)}
+            onBlur={() => setTimeout(() => setFromOpen(false), 120)}
             onChange={(e) => {
-              const val = e.target.value;
-              setFrom(val);
-
-              // после выбора from — автоматически фокусируем to
-              if (val && toRef.current) {
-                setTimeout(() => {
-                  toRef.current && toRef.current.focus();
-                }, 0);
-              }
+              const value = e.target.value;
+              setFromQuery(value);
+              setFrom('');
             }}
-          >
-            <option value="">{depLoading ? t.loading : t.from}</option>
-            {departures.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.stop_name}
-              </option>
-            ))}
-          </select>
-          {/* caret */}
-          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-500">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M6 9l6 6 6-6"
-                stroke="#6b7280"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </span>
+          />
+          {fromOpen && (
+            <div className="absolute z-30 mt-1 w-full max-h-64 overflow-auto rounded-xl border border-gray-200 bg-white shadow-lg">
+              {visibleDepartures.length > 0 ? (
+                visibleDepartures.map((s) => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    className="w-full text-left px-3 py-2 hover:bg-blue-50 text-gray-900"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => {
+                      setFrom(String(s.id));
+                      setFromQuery(s.stop_name);
+                      setFromOpen(false);
+                      setTimeout(() => toRef.current?.focus(), 0);
+                    }}
+                  >
+                    {s.stop_name}
+                  </button>
+                ))
+              ) : (
+                <div className="px-3 py-2 text-sm text-gray-500">{t.noResults}</div>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
-      {/* SWAP — одна кнопка */}
       <button
         type="button"
         title={t.swap}
         onClick={handleSwap}
         disabled={!canSwap}
-        className={`shrink-0 w-10 h-10 rounded-xl border transition flex items-center justify-center
-          ${
-            canSwap
-              ? 'bg-white text-blue-600 hover:border-blue-300'
-              : 'bg-white/60 text-gray-400 cursor-not-allowed'
-          }`}
+        className={`shrink-0 w-10 h-10 rounded-xl border transition flex items-center justify-center ${
+          canSwap ? 'bg-white text-blue-600 hover:border-blue-300' : 'bg-white/60 text-gray-400 cursor-not-allowed'
+        }`}
       >
-        {/* иконка реверса с хорошим контрастом */}
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
           <path
             d="M7 7h10m0 0-3-3m3 3-3 3M17 17H7m0 0 3-3m-3 3 3 3"
@@ -232,37 +330,45 @@ export default function DirectionSelect({
         </svg>
       </button>
 
-      {/* TO */}
       <div className="flex-1 min-w-[180px]">
-        <label className="text-white/90 text-sm mb-1 block select-none">
-          {t.to}
-        </label>
+        <label className="text-white/90 text-sm mb-1 block select-none">{t.to}</label>
         <div className="relative">
-          <select
+          <input
             ref={toRef}
-            className="w-full h-11 px-4 pr-9 bg-white rounded-xl border border-transparent hover:border-blue-300 transition appearance-none text-gray-900 disabled:opacity-60"
-            value={to}
-            onChange={(e) => setTo(e.target.value)}
+            className="w-full h-11 px-4 pr-9 bg-white rounded-xl border border-transparent hover:border-blue-300 transition text-gray-900 disabled:opacity-60"
+            value={toQuery}
+            placeholder={arrLoading ? t.loading : t.to}
+            onFocus={() => setToOpen(true)}
+            onBlur={() => setTimeout(() => setToOpen(false), 120)}
+            onChange={(e) => {
+              setToQuery(e.target.value);
+              setTo('');
+            }}
             disabled={!from}
-          >
-            <option value="">{arrLoading ? t.loading : t.to}</option>
-            {arrivals.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.stop_name}
-              </option>
-            ))}
-          </select>
-          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-500">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M6 9l6 6 6-6"
-                stroke="#6b7280"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </span>
+          />
+          {toOpen && from && (
+            <div className="absolute z-30 mt-1 w-full max-h-64 overflow-auto rounded-xl border border-gray-200 bg-white shadow-lg">
+              {visibleArrivals.length > 0 ? (
+                visibleArrivals.map((s) => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    className="w-full text-left px-3 py-2 hover:bg-blue-50 text-gray-900"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => {
+                      setTo(String(s.id));
+                      setToQuery(s.stop_name);
+                      setToOpen(false);
+                    }}
+                  >
+                    {s.stop_name}
+                  </button>
+                ))
+              ) : (
+                <div className="px-3 py-2 text-sm text-gray-500">{t.noResults}</div>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Improve UX for selecting departure/arrival stops by providing searchable, fuzzy-matched inputs instead of native `select` elements.
- Keep locale-friendly labels and provide a better "no results" feedback for multiple languages.

### Description
- Replaced `<select>` controls with input-based dropdowns and local state (`fromQuery`, `toQuery`, `fromOpen`, `toOpen`) that show a custom list of matches and allow keyboard focus management via refs `fromRef` and `toRef`.
- Added fuzzy filtering utilities: `normalize`, `levenshteinDistance`, and `fuzzyFilterStops` to score and return best matches, and introduced `visibleDepartures`/`visibleArrivals` memos to drive the dropdown lists.
- Sorted fetched stops by `stop_name` using `localeCompare`, and synchronized selected IDs with query strings so external `from`/`to` props remain consistent; fetch logic now clears queries when selections disappear from results.
- Added localized `noResults` messages to the translations and adjusted minor className/markup tweaks and swap button styling while preserving the swap behavior and loading placeholders.

### Testing
- Performed TypeScript type-check with `tsc --noEmit`, which succeeded.
- No new unit tests were added for the component and no existing test behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06de5bfa648327943bd9d5ad7446ca)