### PR TITLE
Replace select dropdowns with searchable stop combobox

### DIFF
--- a/src/components/hero/DirectionSelect.tsx
+++ b/src/components/hero/DirectionSelect.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { API } from '@/config';
+import StopCombobox, { type StopComboboxHandle } from './StopCombobox';
 
 type Lang = 'ru' | 'bg' | 'en' | 'ua';
 
@@ -25,24 +26,28 @@ const T = {
     to: 'Куда',
     swap: 'Поменять направление',
     loading: 'Загрузка…',
+    noMatches: 'Ничего не найдено',
   },
   bg: {
     from: 'Откуда',
     to: 'Куда',
     swap: 'Смяна на посоката',
     loading: 'Зареждане…',
+    noMatches: 'Няма съвпадения',
   },
   en: {
     from: 'From',
     to: 'To',
     swap: 'Swap direction',
     loading: 'Loading…',
+    noMatches: 'No matches',
   },
   ua: {
     from: 'Звідки',
     to: 'Куди',
     swap: 'Поміняти напрям',
     loading: 'Завантаження…',
+    noMatches: 'Нічого не знайдено',
   },
 };
 
@@ -65,8 +70,8 @@ export default function DirectionSelect({
   const [arrivals, setArrivals] = useState<Stop[]>([]);
 
   // refs для авто-перехода фокуса from → to
-  const fromRef = useRef<HTMLSelectElement | null>(null);
-  const toRef = useRef<HTMLSelectElement | null>(null);
+  const fromRef = useRef<StopComboboxHandle | null>(null);
+  const toRef = useRef<StopComboboxHandle | null>(null);
 
   // Загрузка отправных остановок
   useEffect(() => {
@@ -168,43 +173,19 @@ export default function DirectionSelect({
         <label className="text-white/90 text-sm mb-1 block select-none">
           {t.from}
         </label>
-        <div className="relative">
-          <select
-            ref={fromRef}
-            className="w-full h-11 px-4 pr-9 bg-white rounded-xl border border-transparent hover:border-blue-300 transition appearance-none text-gray-900"
-            value={from}
-            onChange={(e) => {
-              const val = e.target.value;
-              setFrom(val);
-
-              // после выбора from — автоматически фокусируем to
-              if (val && toRef.current) {
-                setTimeout(() => {
-                  toRef.current && toRef.current.focus();
-                }, 0);
-              }
-            }}
-          >
-            <option value="">{depLoading ? t.loading : t.from}</option>
-            {departures.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.stop_name}
-              </option>
-            ))}
-          </select>
-          {/* caret */}
-          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-500">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M6 9l6 6 6-6"
-                stroke="#6b7280"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </span>
-        </div>
+        <StopCombobox
+          ref={fromRef}
+          stops={departures}
+          value={from}
+          onChange={setFrom}
+          onSelect={(val) => {
+            if (val) setTimeout(() => toRef.current?.focus(), 0);
+          }}
+          placeholder={depLoading ? t.loading : t.from}
+          ariaLabel={t.from}
+          inputClassName="w-full h-11 px-4 bg-white rounded-xl border border-transparent hover:border-blue-300 transition text-gray-900 focus:outline-none focus:border-blue-300"
+          noOptionsText={t.noMatches}
+        />
       </div>
 
       {/* SWAP — одна кнопка */}
@@ -237,33 +218,17 @@ export default function DirectionSelect({
         <label className="text-white/90 text-sm mb-1 block select-none">
           {t.to}
         </label>
-        <div className="relative">
-          <select
-            ref={toRef}
-            className="w-full h-11 px-4 pr-9 bg-white rounded-xl border border-transparent hover:border-blue-300 transition appearance-none text-gray-900 disabled:opacity-60"
-            value={to}
-            onChange={(e) => setTo(e.target.value)}
-            disabled={!from}
-          >
-            <option value="">{arrLoading ? t.loading : t.to}</option>
-            {arrivals.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.stop_name}
-              </option>
-            ))}
-          </select>
-          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-500">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M6 9l6 6 6-6"
-                stroke="#6b7280"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </span>
-        </div>
+        <StopCombobox
+          ref={toRef}
+          stops={arrivals}
+          value={to}
+          onChange={setTo}
+          disabled={!from}
+          placeholder={arrLoading ? t.loading : t.to}
+          ariaLabel={t.to}
+          inputClassName="w-full h-11 px-4 bg-white rounded-xl border border-transparent hover:border-blue-300 transition text-gray-900 disabled:opacity-60 focus:outline-none focus:border-blue-300"
+          noOptionsText={t.noMatches}
+        />
       </div>
     </div>
   );

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Calendar from '../Calendar';
 import DateInput from './DateInput';
 import PassengersInput from './PassengersInput';
+import StopCombobox, { type StopComboboxHandle } from './StopCombobox';
 import apiClient from '@/lib/apiClient';
 import { useLockBodyScroll } from '@/utils/useLockBodyScroll';
 import { useModalVisibility } from '@/utils/useModalVisibility';
@@ -41,6 +42,7 @@ const L = {
     back: 'Обратно',
     search: 'Поиск',
     swapTitle: 'Поменять местами',
+    noMatches: 'Ничего не найдено',
   },
   en: {
     from: 'From',
@@ -49,6 +51,7 @@ const L = {
     back: 'Return',
     search: 'Search',
     swapTitle: 'Swap',
+    noMatches: 'No matches',
   },
   bg: {
     from: 'Откъде',
@@ -57,6 +60,7 @@ const L = {
     back: 'Обратно',
     search: 'Търсене',
     swapTitle: 'Размени',
+    noMatches: 'Няма съвпадения',
   },
   ua: {
     from: 'Звідки',
@@ -65,6 +69,7 @@ const L = {
     back: 'Назад',
     search: 'Пошук',
     swapTitle: 'Поміняти місцями',
+    noMatches: 'Нічого не знайдено',
   },
 };
 
@@ -113,8 +118,8 @@ export default function SearchForm({
   const toId = useMemo(() => Number(to) || 0, [to]);
 
   // refs для авто-переходов внутри формы
-  const fromSelectRef = useRef<HTMLSelectElement | null>(null);
-  const toSelectRef = useRef<HTMLSelectElement | null>(null);
+  const fromSelectRef = useRef<StopComboboxHandle | null>(null);
+  const toSelectRef = useRef<StopComboboxHandle | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -245,34 +250,21 @@ export default function SearchForm({
       <div className="relative grid gap-4 md:grid-cols-[1fr_auto_1fr] md:items-end">
         <div className="flex flex-col gap-2">
           <span className={labelStyles}>{t.from}</span>
-          <div className="relative">
-            <select
-              ref={fromSelectRef}
-              aria-label={t.from}
-              className={`${baseFieldStyles} pr-12 appearance-none`}
-              value={from}
-              onChange={(e) => {
-                const val = e.target.value;
-                setFrom(val);
-
-                if (val && toSelectRef.current) {
-                  setTimeout(() => {
-                    toSelectRef.current?.focus();
-                  }, 0);
-                }
-              }}
-            >
-              <option value="">{t.from}</option>
-              {departureStops.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.stop_name}
-                </option>
-              ))}
-            </select>
-            <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-slate-400">
-              ▼
-            </span>
-          </div>
+          <StopCombobox
+            ref={fromSelectRef}
+            stops={departureStops}
+            value={from}
+            onChange={setFrom}
+            onSelect={(val) => {
+              if (val) {
+                setTimeout(() => toSelectRef.current?.focus(), 0);
+              }
+            }}
+            placeholder={t.from}
+            ariaLabel={t.from}
+            inputClassName={`${baseFieldStyles} pr-4`}
+            noOptionsText={t.noMatches}
+          />
         </div>
 
         <div className="absolute left-1/2 top-1/2 z-10 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center md:static md:translate-x-0 md:translate-y-0 md:pb-1">
@@ -290,33 +282,20 @@ export default function SearchForm({
 
         <div className="flex flex-col gap-2">
           <span className={labelStyles}>{t.to}</span>
-          <div className="relative">
-            <select
-              ref={toSelectRef}
-              aria-label={t.to}
-              className={`${baseFieldStyles} pr-12 appearance-none disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400`}
-              value={to}
-              onChange={(e) => {
-                const val = e.target.value;
-                setTo(val);
-
-                if (val && fromId) {
-                  handleDepartOpen();
-                }
-              }}
-              disabled={!fromId}
-            >
-              <option value="">{t.to}</option>
-              {arrivalStops.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.stop_name}
-                </option>
-              ))}
-            </select>
-            <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-slate-400">
-              ▼
-            </span>
-          </div>
+          <StopCombobox
+            ref={toSelectRef}
+            stops={arrivalStops}
+            value={to}
+            onChange={setTo}
+            onSelect={(val) => {
+              if (val && fromId) handleDepartOpen();
+            }}
+            disabled={!fromId}
+            placeholder={t.to}
+            ariaLabel={t.to}
+            inputClassName={`${baseFieldStyles} pr-4 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400`}
+            noOptionsText={t.noMatches}
+          />
         </div>
       </div>
 

--- a/src/components/hero/StopCombobox.tsx
+++ b/src/components/hero/StopCombobox.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+export type Stop = { id: number; stop_name: string };
+
+export type StopComboboxHandle = {
+  focus: () => void;
+};
+
+type Props = {
+  stops: Stop[];
+  value: string;
+  onChange: (id: string) => void;
+  onSelect?: (id: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  ariaLabel?: string;
+  inputClassName?: string;
+  noOptionsText?: string;
+};
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (!a.length) return b.length;
+  if (!b.length) return a.length;
+  let prev = new Array(b.length + 1);
+  let curr = new Array(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length];
+}
+
+function scoreStop(name: string, query: string): number {
+  const n = name.toLowerCase();
+  const q = query.toLowerCase();
+  if (!q) return 0;
+
+  const idx = n.indexOf(q);
+  if (idx >= 0) return idx === 0 ? 0 : 1 + idx * 0.01;
+
+  const len = q.length;
+  let best = Infinity;
+
+  if (n.length >= len) {
+    for (let i = 0; i <= n.length - len; i++) {
+      const d = levenshtein(n.substring(i, i + len), q);
+      if (d < best) best = d;
+      if (best === 0) break;
+    }
+  } else {
+    best = levenshtein(n, q);
+  }
+
+  for (const word of n.split(/[\s,\-–—()]+/)) {
+    if (!word) continue;
+    const d = levenshtein(word, q);
+    if (d < best) best = d;
+  }
+
+  return 10 + best;
+}
+
+const StopCombobox = forwardRef<StopComboboxHandle, Props>(function StopCombobox(
+  {
+    stops,
+    value,
+    onChange,
+    onSelect,
+    placeholder,
+    disabled,
+    ariaLabel,
+    inputClassName = '',
+    noOptionsText = 'Нет совпадений',
+  },
+  ref,
+) {
+  const [query, setQuery] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [typing, setTyping] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const listboxId = React.useId();
+
+  useImperativeHandle(ref, () => ({
+    focus: () => inputRef.current?.focus(),
+  }));
+
+  const selectedName = useMemo(() => {
+    if (!value) return '';
+    return stops.find((s) => String(s.id) === String(value))?.stop_name ?? '';
+  }, [value, stops]);
+
+  const sortedStops = useMemo(
+    () =>
+      [...stops].sort((a, b) =>
+        a.stop_name.localeCompare(b.stop_name, undefined, {
+          sensitivity: 'base',
+        }),
+      ),
+    [stops],
+  );
+
+  // Keep input in sync with selected value when not actively typing.
+  useEffect(() => {
+    if (!typing) setQuery(selectedName);
+  }, [selectedName, typing]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim();
+    if (!q || (!typing && q === selectedName)) return sortedStops;
+    const threshold = Math.max(2, Math.ceil(q.length / 2));
+    return sortedStops
+      .map((s) => ({ stop: s, score: scoreStop(s.stop_name, q) }))
+      .filter((x) => x.score < 10 + threshold)
+      .sort(
+        (a, b) =>
+          a.score - b.score ||
+          a.stop.stop_name.localeCompare(b.stop.stop_name, undefined, {
+            sensitivity: 'base',
+          }),
+      )
+      .map((x) => x.stop);
+  }, [query, sortedStops, selectedName, typing]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !listRef.current) return;
+    const el = listRef.current.children[activeIndex] as
+      | HTMLElement
+      | undefined;
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, isOpen]);
+
+  useEffect(() => {
+    function onDocDown(e: MouseEvent) {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+        setTyping(false);
+        setQuery(selectedName);
+      }
+    }
+    if (isOpen) document.addEventListener('mousedown', onDocDown);
+    return () => document.removeEventListener('mousedown', onDocDown);
+  }, [isOpen, selectedName]);
+
+  const pickStop = (s: Stop) => {
+    onChange(String(s.id));
+    setQuery(s.stop_name);
+    setTyping(false);
+    setIsOpen(false);
+    onSelect?.(String(s.id));
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setIsOpen(true);
+      setActiveIndex((i) => Math.min(filtered.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter') {
+      if (isOpen && filtered[activeIndex]) {
+        e.preventDefault();
+        pickStop(filtered[activeIndex]);
+      }
+    } else if (e.key === 'Escape') {
+      setIsOpen(false);
+      setTyping(false);
+      setQuery(selectedName);
+      inputRef.current?.blur();
+    } else if (e.key === 'Tab') {
+      setIsOpen(false);
+      setTyping(false);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-label={ariaLabel}
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        autoComplete="off"
+        spellCheck={false}
+        className={inputClassName}
+        value={query}
+        placeholder={placeholder}
+        disabled={disabled}
+        onFocus={() => {
+          setIsOpen(true);
+          requestAnimationFrame(() => inputRef.current?.select());
+        }}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setTyping(true);
+          setIsOpen(true);
+          if (value) onChange('');
+        }}
+        onKeyDown={onKeyDown}
+      />
+      {isOpen && !disabled && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          className="absolute left-0 right-0 z-30 mt-1 max-h-64 overflow-auto rounded-xl bg-white shadow-lg ring-1 ring-slate-200"
+        >
+          {filtered.length === 0 ? (
+            <li className="px-4 py-2 text-sm text-slate-400">
+              {noOptionsText}
+            </li>
+          ) : (
+            filtered.map((s, idx) => (
+              <li
+                key={s.id}
+                role="option"
+                aria-selected={idx === activeIndex}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  pickStop(s);
+                }}
+                onMouseEnter={() => setActiveIndex(idx)}
+                className={`cursor-pointer px-4 py-2 text-sm ${
+                  idx === activeIndex
+                    ? 'bg-sky-50 text-sky-700'
+                    : 'text-slate-800 hover:bg-slate-50'
+                }`}
+              >
+                {s.stop_name}
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+});
+
+export default StopCombobox;


### PR DESCRIPTION
## Summary
Replaced native HTML `<select>` elements with a custom `StopCombobox` component that provides fuzzy search functionality for transit stops. This improves user experience by allowing users to search for stops by name rather than scrolling through a potentially long list.

## Key Changes
- **New Component**: Created `StopCombobox.tsx` - a fully accessible combobox component with:
  - Fuzzy search using Levenshtein distance algorithm
  - Smart scoring that prioritizes exact substring matches and word boundaries
  - Full keyboard navigation (Arrow Up/Down, Enter, Escape, Tab)
  - Proper ARIA attributes for accessibility (combobox, listbox, option roles)
  - Auto-scrolling to keep active item in view
  - Click-outside detection to close dropdown
  - Ref forwarding for imperative focus control

- **Updated Components**:
  - `DirectionSelect.tsx`: Replaced both "from" and "to" select elements with `StopCombobox`
  - `SearchForm.tsx`: Replaced both "from" and "to" select elements with `StopCombobox`
  - Updated ref types from `HTMLSelectElement` to `StopComboboxHandle`
  - Added `noMatches` translation strings to all language variants (ru, en, bg, ua)

## Implementation Details
- The combobox uses a sophisticated scoring algorithm that:
  - Returns 0 for exact matches
  - Prioritizes substring matches at the start of the name
  - Falls back to Levenshtein distance for fuzzy matching
  - Checks individual words separated by spaces, commas, hyphens, etc.
  - Filters results with a dynamic threshold based on query length
  
- Maintains input synchronization with selected value when not actively typing
- Preserves auto-focus behavior: selecting "from" automatically focuses "to"
- Supports disabled state for the "to" field when "from" is not selected
- Fully keyboard accessible with proper ARIA attributes for screen readers

https://claude.ai/code/session_01K8AyjkvrfVN9RTY1eNcTCW