### PR TITLE
Fix GA4 purchase revenue tracking with validated item-based value

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "postinstall": "node scripts/fix-css-hmr.js",
-    "test": "npm run test:build && node --test .tmp-tests/passengerContact.test.js",
-    "test:build": "tsc --module commonjs --target es2020 --outDir .tmp-tests src/utils/passengerContact.ts src/utils/passengerContact.test.ts"
+    "test": "npm run test:build && node --test .tmp-tests/passengerContact.test.js .tmp-tests/lib/analytics.test.js",
+    "test:build": "tsc --module commonjs --target es2020 --outDir .tmp-tests --rootDir src --esModuleInterop --skipLibCheck src/utils/passengerContact.ts src/utils/passengerContact.test.ts src/lib/analytics.ts src/lib/analytics.test.ts"
   },
   "dependencies": {
     "axios": "^1.11.0",

--- a/src/app/[locale]/(site)/return/page.tsx
+++ b/src/app/[locale]/(site)/return/page.tsx
@@ -12,6 +12,7 @@ import type { PurchaseView, PurchaseTicket } from "@/types/purchase";
 import { useLanguage } from "@/components/common/LanguageProvider";
 import {
   trackEvent,
+  trackPurchase,
   buildRouteCategory,
   daysUntil,
   FALLBACK_CURRENCY,
@@ -697,8 +698,6 @@ function ReturnPageContent() {
 
   const firePurchaseEvent = (purchaseView: PurchaseView, purchaseId: string) => {
     if (typeof window === "undefined") return;
-    const firedKey = `ga_purchase_fired_${purchaseId}`;
-    if (sessionStorage.getItem(firedKey)) return;
 
     const tickets = purchaseView.tickets ?? [];
     const trips = purchaseView.trips ?? [];
@@ -724,36 +723,54 @@ function ReturnPageContent() {
       : null;
     const daysUntilDeparture = daysUntil(earliestDeparture);
 
-    trackEvent("purchase", {
-      transaction_id: String(purchaseView.purchase.id ?? purchaseId),
-      value: purchaseView.totals?.paid ?? purchaseView.purchase.amount_due,
-      currency: purchaseView.purchase.currency ?? FALLBACK_CURRENCY,
-      items: tickets.map((ticket) => {
-        const direction = directionByTicketId.get(String(ticket.id));
-        const departureName = ticket.segment_details?.departure?.name ?? "";
-        const arrivalName = ticket.segment_details?.arrival?.name ?? "";
-        return {
-          item_id: String(ticket.id),
-          item_name: `${departureName} → ${arrivalName}`,
-          item_category: isRoundtrip ? "roundtrip" : "oneway",
-          item_category2: buildRouteCategory(
-            { id: ticket.segment_details?.departure?.id, name: departureName },
-            { id: ticket.segment_details?.arrival?.id, name: arrivalName },
-          ),
-          item_variant: direction,
-          price: ticket.pricing?.price ?? 0,
-          quantity: 1,
-        };
-      }),
-      passenger_count: tickets.length,
-      trip_type: isRoundtrip ? "roundtrip" : "oneway",
-      days_until_departure: daysUntilDeparture,
-      payment_method: "liqpay",
+    const transactionId = String(
+      purchaseView.purchase.id ?? purchaseId,
+    );
+
+    const uniqueTickets = Array.from(
+      new Map(tickets.map((ticket) => [String(ticket.id), ticket])).values(),
+    );
+
+    const items = uniqueTickets.map((ticket) => {
+      const direction = directionByTicketId.get(String(ticket.id));
+      const departureName = ticket.segment_details?.departure?.name ?? "";
+      const arrivalName = ticket.segment_details?.arrival?.name ?? "";
+      return {
+        item_id: String(ticket.id),
+        item_name: `${departureName} → ${arrivalName}`,
+        item_category: isRoundtrip ? "roundtrip" : "oneway",
+        item_category2: buildRouteCategory(
+          { id: ticket.segment_details?.departure?.id, name: departureName },
+          { id: ticket.segment_details?.arrival?.id, name: arrivalName },
+        ),
+        item_variant: direction,
+        price: ticket.pricing?.price,
+        quantity: 1,
+      };
     });
 
-    sessionStorage.setItem(firedKey, "1");
-    sessionStorage.removeItem("ga_checkout_start_ts");
-    sessionStorage.removeItem("ga_checkout_purchase_id");
+    const fired = trackPurchase({
+      transactionId,
+      items,
+      currency: purchaseView.purchase.currency ?? FALLBACK_CURRENCY,
+      valueOverride:
+        purchaseView.totals?.paid ?? purchaseView.purchase.amount_due,
+      extra: {
+        passenger_count: uniqueTickets.length,
+        trip_type: isRoundtrip ? "roundtrip" : "oneway",
+        days_until_departure: daysUntilDeparture,
+        payment_method: "liqpay",
+      },
+    });
+
+    if (fired) {
+      try {
+        sessionStorage.removeItem("ga_checkout_start_ts");
+        sessionStorage.removeItem("ga_checkout_purchase_id");
+      } catch {
+        /* ignore */
+      }
+    }
   };
 
   const queryPurchaseId = useMemo(() => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { LanguageProvider } from "@/components/common/LanguageProvider";
 import { DEFAULT_LOCALE, HOME_META, OG_IMAGE, SITE_URL, isLocale, toHtmlLang } from "@/lib/seo";
 
 const GA_MEASUREMENT_ID = "G-N3PVQB5J6S";
+const GA_DEBUG_MODE = process.env.NODE_ENV !== "production";
 
 export const metadata = {
   metadataBase: new URL(SITE_URL),
@@ -44,7 +45,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', '${GA_MEASUREMENT_ID}');
+            gtag('config', '${GA_MEASUREMENT_ID}'${GA_DEBUG_MODE ? ", { debug_mode: true }" : ""});
           `}
         </Script>
       </head>

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,238 @@
+import { test, beforeEach } from "node:test";
+import * as assert from "node:assert/strict";
+
+import {
+  toFiniteNumber,
+  trackPurchase,
+  FALLBACK_CURRENCY,
+} from "./analytics";
+
+type GtagCall = { event: string; params: Record<string, unknown> };
+
+type MutableStorage = {
+  store: Map<string, string>;
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+  clear(): void;
+};
+
+const createStorage = (): MutableStorage => {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => store.clear(),
+  };
+};
+
+const installWindow = (): { calls: GtagCall[]; reset: () => void } => {
+  const calls: GtagCall[] = [];
+  const sessionStorage = createStorage();
+  const localStorage = createStorage();
+  const gtag = (..._args: unknown[]) => {
+    const [type, event, params] = _args as [
+      string,
+      string,
+      Record<string, unknown> | undefined,
+    ];
+    if (type === "event") {
+      calls.push({ event, params: params ?? {} });
+    }
+  };
+  const g = globalThis as Record<string, unknown>;
+  g.window = {
+    gtag,
+    sessionStorage,
+    localStorage,
+    location: { search: "" },
+    navigator: { userAgent: "node-test" },
+  };
+  g.sessionStorage = sessionStorage;
+  g.localStorage = localStorage;
+  return {
+    calls,
+    reset: () => {
+      calls.length = 0;
+      sessionStorage.clear();
+      localStorage.clear();
+    },
+  };
+};
+
+const ctx = installWindow();
+
+beforeEach(() => {
+  ctx.reset();
+});
+
+test("toFiniteNumber accepts plain numbers", () => {
+  assert.equal(toFiniteNumber(0), 0);
+  assert.equal(toFiniteNumber(2600), 2600);
+  assert.equal(toFiniteNumber(-15.5), -15.5);
+});
+
+test("toFiniteNumber rejects NaN and Infinity", () => {
+  assert.equal(toFiniteNumber(NaN), null);
+  assert.equal(toFiniteNumber(Infinity), null);
+  assert.equal(toFiniteNumber(-Infinity), null);
+});
+
+test("toFiniteNumber parses common string formats", () => {
+  assert.equal(toFiniteNumber("2600"), 2600);
+  assert.equal(toFiniteNumber("2600.50"), 2600.5);
+  assert.equal(toFiniteNumber("2,600.00"), 2600);
+  assert.equal(toFiniteNumber("2.600,00"), 2600);
+  assert.equal(toFiniteNumber("2 600,00"), 2600);
+  assert.equal(toFiniteNumber("2 600"), 2600);
+  assert.equal(toFiniteNumber("  72373  "), 72373);
+});
+
+test("toFiniteNumber rejects unparseable values", () => {
+  assert.equal(toFiniteNumber(""), null);
+  assert.equal(toFiniteNumber("abc"), null);
+  assert.equal(toFiniteNumber(null), null);
+  assert.equal(toFiniteNumber(undefined), null);
+  assert.equal(toFiniteNumber({}), null);
+});
+
+test("trackPurchase uses sum of item prices as canonical value", () => {
+  const fired = trackPurchase({
+    transactionId: "tx-1",
+    items: [
+      { item_id: "t1", item_name: "Trip A", price: 2600, quantity: 1 },
+    ],
+    currency: "UAH",
+  });
+
+  assert.equal(fired, true);
+  assert.equal(ctx.calls.length, 1);
+  const call = ctx.calls[0];
+  assert.equal(call.event, "purchase");
+  assert.equal(call.params.value, 2600);
+  assert.equal(call.params.transaction_id, "tx-1");
+  assert.equal(call.params.currency, "UAH");
+});
+
+test("trackPurchase sums multiple items correctly", () => {
+  trackPurchase({
+    transactionId: "tx-2",
+    items: [
+      { item_id: "a", price: 2600, quantity: 1 },
+      { item_id: "b", price: 2600, quantity: 1 },
+    ],
+  });
+
+  assert.equal(ctx.calls[0]?.params.value, 5200);
+});
+
+test("trackPurchase coerces string prices to numbers", () => {
+  trackPurchase({
+    transactionId: "tx-3",
+    items: [{ item_id: "a", price: "2 600,00" as unknown as number }],
+  });
+
+  assert.equal(ctx.calls[0]?.params.value, 2600);
+});
+
+test("trackPurchase prefers items value over valueOverride", () => {
+  trackPurchase({
+    transactionId: "tx-4",
+    items: [{ item_id: "a", price: 2600, quantity: 1 }],
+    valueOverride: 72373,
+  });
+
+  assert.equal(ctx.calls[0]?.params.value, 2600);
+});
+
+test("trackPurchase falls back to valueOverride when items have no price", () => {
+  trackPurchase({
+    transactionId: "tx-5",
+    items: [{ item_id: "a", price: null, quantity: 1 }],
+    valueOverride: 1500,
+  });
+
+  assert.equal(ctx.calls[0]?.params.value, 1500);
+});
+
+test("trackPurchase skips event when value is invalid", () => {
+  const fired = trackPurchase({
+    transactionId: "tx-6",
+    items: [{ item_id: "a", price: null }],
+  });
+
+  assert.equal(fired, false);
+  assert.equal(ctx.calls.length, 0);
+});
+
+test("trackPurchase skips event when transactionId is missing", () => {
+  const fired = trackPurchase({
+    transactionId: "",
+    items: [{ item_id: "a", price: 2600 }],
+  });
+
+  assert.equal(fired, false);
+  assert.equal(ctx.calls.length, 0);
+});
+
+test("trackPurchase prevents duplicate events with same transactionId", () => {
+  const first = trackPurchase({
+    transactionId: "tx-dup",
+    items: [{ item_id: "a", price: 2600 }],
+  });
+  const second = trackPurchase({
+    transactionId: "tx-dup",
+    items: [{ item_id: "a", price: 2600 }],
+  });
+
+  assert.equal(first, true);
+  assert.equal(second, false);
+  assert.equal(ctx.calls.length, 1);
+});
+
+test("trackPurchase applies fallback currency when not provided", () => {
+  trackPurchase({
+    transactionId: "tx-cur",
+    items: [{ item_id: "a", price: 2600 }],
+  });
+
+  assert.equal(ctx.calls[0]?.params.currency, FALLBACK_CURRENCY);
+});
+
+test("trackPurchase normalizes invalid quantity to 1", () => {
+  trackPurchase({
+    transactionId: "tx-qty",
+    items: [{ item_id: "a", price: 2600, quantity: 0 }],
+  });
+
+  const items = ctx.calls[0]?.params.items as Array<{ quantity: number }>;
+  assert.equal(items[0].quantity, 1);
+  assert.equal(ctx.calls[0]?.params.value, 2600);
+});
+
+test("trackPurchase preserves extra event params", () => {
+  trackPurchase({
+    transactionId: "tx-extra",
+    items: [{ item_id: "a", price: 2600 }],
+    extra: { passenger_count: 2, trip_type: "roundtrip" },
+  });
+
+  assert.equal(ctx.calls[0]?.params.passenger_count, 2);
+  assert.equal(ctx.calls[0]?.params.trip_type, "roundtrip");
+});
+
+test("trackPurchase rounds value to 2 decimals", () => {
+  trackPurchase({
+    transactionId: "tx-round",
+    items: [{ item_id: "a", price: 100.567, quantity: 3 }],
+  });
+
+  const value = ctx.calls[0]?.params.value as number;
+  assert.equal(value, 301.71);
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -100,3 +100,195 @@ export const daysUntil = (futureMs: number | null | undefined): number | undefin
   if (!futureMs || !Number.isFinite(futureMs)) return undefined;
   return Math.max(0, Math.floor((futureMs - Date.now()) / 86400000));
 };
+
+export const toFiniteNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const cleaned = trimmed.replace(/[\s ]/g, "");
+    const lastComma = cleaned.lastIndexOf(",");
+    const lastDot = cleaned.lastIndexOf(".");
+    let normalized = cleaned;
+    if (lastComma > lastDot) {
+      normalized = normalized.replace(/\./g, "").replace(",", ".");
+    } else if (lastDot > lastComma) {
+      normalized = normalized.replace(/,/g, "");
+    } else if (lastComma >= 0) {
+      normalized = normalized.replace(",", ".");
+    }
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+export type PurchaseEventItem = {
+  item_id: string;
+  item_name?: string;
+  item_category?: string;
+  item_category2?: string;
+  item_variant?: string;
+  price?: number | string | null;
+  quantity?: number | string | null;
+  [extra: string]: unknown;
+};
+
+export type TrackPurchaseParams = {
+  transactionId: string | number | null | undefined;
+  items: PurchaseEventItem[];
+  currency?: string | null;
+  valueOverride?: number | string | null;
+  extra?: GtagParams;
+};
+
+const PURCHASE_FIRED_KEY_PREFIX = "ga_purchase_fired_";
+const MAX_REASONABLE_PURCHASE_VALUE = 1_000_000;
+
+const isDev = () => process.env.NODE_ENV !== "production";
+
+const safeStorageGet = (key: string): string | null => {
+  try {
+    return (
+      window.sessionStorage?.getItem(key) ??
+      window.localStorage?.getItem(key) ??
+      null
+    );
+  } catch {
+    return null;
+  }
+};
+
+const safeStorageSet = (key: string, value: string) => {
+  try {
+    window.sessionStorage?.setItem(key, value);
+  } catch {
+    /* ignore */
+  }
+  try {
+    window.localStorage?.setItem(key, value);
+  } catch {
+    /* ignore */
+  }
+};
+
+export const trackPurchase = (params: TrackPurchaseParams): boolean => {
+  if (typeof window === "undefined") return false;
+
+  const transactionId =
+    params.transactionId !== null && params.transactionId !== undefined
+      ? String(params.transactionId).trim()
+      : "";
+  if (!transactionId) {
+    if (isDev()) {
+      console.error(
+        "[Analytics] purchase event skipped: missing transactionId",
+      );
+    }
+    return false;
+  }
+
+  const items = Array.isArray(params.items) ? params.items : [];
+  const normalizedItems = items.map((item) => {
+    const price = toFiniteNumber(item.price);
+    const quantity = toFiniteNumber(item.quantity);
+    const safePrice = price !== null && price > 0 ? Number(price.toFixed(2)) : 0;
+    const safeQty = quantity !== null && quantity > 0 ? quantity : 1;
+    return {
+      ...item,
+      item_id: String(item.item_id ?? ""),
+      price: safePrice,
+      quantity: safeQty,
+    };
+  });
+
+  const itemsValue = normalizedItems.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0,
+  );
+
+  const overrideValue = toFiniteNumber(params.valueOverride);
+  const value =
+    itemsValue > 0
+      ? itemsValue
+      : overrideValue !== null && overrideValue > 0
+        ? overrideValue
+        : 0;
+
+  if (!Number.isFinite(value) || value <= 0) {
+    if (isDev()) {
+      console.error("[Analytics] purchase event skipped: invalid value", {
+        transactionId,
+        value,
+        itemsValue,
+        valueOverride: params.valueOverride,
+        items: normalizedItems,
+      });
+    }
+    return false;
+  }
+
+  if (
+    overrideValue !== null &&
+    itemsValue > 0 &&
+    Math.abs(overrideValue - itemsValue) > Math.max(1, itemsValue * 0.05)
+  ) {
+    if (isDev()) {
+      console.warn(
+        "[Analytics] purchase value mismatch (items vs override)",
+        {
+          transactionId,
+          itemsValue,
+          overrideValue,
+        },
+      );
+    }
+  }
+
+  if (value > MAX_REASONABLE_PURCHASE_VALUE) {
+    if (isDev()) {
+      console.warn("[Analytics] purchase value is unusually high", {
+        transactionId,
+        value,
+      });
+    }
+  }
+
+  const firedKey = `${PURCHASE_FIRED_KEY_PREFIX}${transactionId}`;
+  if (safeStorageGet(firedKey)) {
+    if (isDev()) {
+      console.debug("[Analytics] purchase event skipped: already fired", {
+        transactionId,
+      });
+    }
+    return false;
+  }
+
+  const roundedValue = Number(value.toFixed(2));
+  const payload: GtagParams = {
+    transaction_id: transactionId,
+    value: roundedValue,
+    currency: params.currency || FALLBACK_CURRENCY,
+    items: normalizedItems,
+    ...(params.extra ?? {}),
+  };
+
+  trackEvent("purchase", payload);
+  safeStorageSet(firedKey, String(Date.now()));
+
+  if (isDev()) {
+    console.log("[Analytics] purchase event fired", {
+      transactionId,
+      value: roundedValue,
+      itemsCount: normalizedItems.length,
+      itemsValue,
+      currency: payload.currency,
+    });
+  }
+
+  return true;
+};


### PR DESCRIPTION
Compute the purchase event value from the sum of normalized ticket prices instead of the raw totals.paid field, which could be a string or contain inflated/aggregated amounts that GA4 was reporting as revenue. Add a reusable trackPurchase helper in lib/analytics that coerces prices to numbers, validates the result is finite and positive, deduplicates by transaction id across sessionStorage and localStorage, logs structured diagnostics in development, and warns when the items total disagrees with the override value. Enable GA4 debug_mode in non-production builds for DebugView visibility.