### PR TITLE
Add BCP 47 og:locale and og:locale:alternate per page

### DIFF
--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -26,3 +26,14 @@ export function toHreflang(locale: Lang): string {
 export function toHtmlLang(locale: Lang): string {
   return HREFLANG_MAP[locale];
 }
+
+const OG_LOCALE_MAP: Record<Lang, string> = {
+  ru: "ru_RU",
+  ua: "uk_UA",
+  en: "en_US",
+  bg: "bg_BG",
+};
+
+export function toOgLocale(locale: Lang): string {
+  return OG_LOCALE_MAP[locale];
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -8,6 +8,7 @@ import {
   localeToPathPrefix,
   toHreflang,
   toHtmlLang,
+  toOgLocale,
 } from "@/lib/locale";
 import { tripsData, type Trip } from "@/lib/tripsData";
 
@@ -115,7 +116,8 @@ export function buildHomeMetadata(locale: Lang): Metadata {
       description: meta.description,
       url: alternates.canonical,
       siteName: "Maximov Tours",
-      locale: toHtmlLang(locale),
+      locale: toOgLocale(locale),
+      alternateLocale: LOCALES.filter((l) => l !== locale).map(toOgLocale),
       type: "website",
       images: [OG_IMAGE],
     },
@@ -143,7 +145,8 @@ export function buildTripMetadata(tripKey: string, locale: Lang): Metadata | nul
       description: data.description,
       url: alternates.canonical,
       siteName: "Maximov Tours",
-      locale: toHtmlLang(locale),
+      locale: toOgLocale(locale),
+      alternateLocale: LOCALES.filter((l) => l !== locale).map(toOgLocale),
       type: "website",
       images: [OG_IMAGE],
     },


### PR DESCRIPTION
Strengthens per-locale signals for OpenGraph consumers (Facebook, some search signals) by emitting og:locale in BCP 47 form (ru_RU/uk_UA/bg_BG/en_US) and og:locale:alternate for the other three locales on every home and trip page. Existing hreflang, canonical, sitemap, and <html lang> behavior is unchanged.

https://claude.ai/code/session_01DwRNXqhEa2UDv6NccTN8BZ