### PR TITLE
Track booking_success event in GA4 on successful reservation

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -18,6 +18,7 @@ import StepThree from "./steps/StepThree";
 import { downloadTicketPdf } from "@/utils/ticketPdf";
 import {
   trackEvent,
+  trackBooking,
   buildRouteCategory,
   FALLBACK_CURRENCY,
 } from "@/lib/analytics";
@@ -534,6 +535,16 @@ export default function SearchResults({
             ).toFixed(2)}`
       );
       setMsgType("success");
+
+      if (action === "book") {
+        trackBooking({
+          purchaseId: pId,
+          tripFrom: fromName,
+          tripTo: toName,
+          value: Number(total),
+          currency: FALLBACK_CURRENCY,
+        });
+      }
 
       if (action === "purchase" && !isTwoStepPurchaseFallback) {
         const checkoutData =

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -292,3 +292,63 @@ export const trackPurchase = (params: TrackPurchaseParams): boolean => {
 
   return true;
 };
+
+const BOOKING_FIRED_KEY_PREFIX = "ga_booking_fired_";
+
+export type TrackBookingParams = {
+  purchaseId: string | number | null | undefined;
+  tripFrom: string;
+  tripTo: string;
+  value?: number | string | null;
+  currency?: string | null;
+};
+
+export const trackBooking = (params: TrackBookingParams): boolean => {
+  if (typeof window === "undefined") return false;
+
+  const purchaseId =
+    params.purchaseId !== null && params.purchaseId !== undefined
+      ? String(params.purchaseId).trim()
+      : "";
+  if (!purchaseId) {
+    if (isDev()) {
+      console.error("[Analytics] booking_success skipped: missing purchaseId");
+    }
+    return false;
+  }
+
+  const firedKey = `${BOOKING_FIRED_KEY_PREFIX}${purchaseId}`;
+  if (safeStorageGet(firedKey)) {
+    if (isDev()) {
+      console.debug("[Analytics] booking_success skipped: already fired", {
+        purchaseId,
+      });
+    }
+    return false;
+  }
+
+  const payload: GtagParams = {
+    transaction_id: purchaseId,
+    trip_from: params.tripFrom,
+    trip_to: params.tripTo,
+    currency: params.currency || FALLBACK_CURRENCY,
+  };
+
+  const numericValue = toFiniteNumber(params.value);
+  if (numericValue !== null && numericValue > 0) {
+    payload.value = Number(numericValue.toFixed(2));
+  }
+
+  trackEvent("booking_success", payload);
+  safeStorageSet(firedKey, String(Date.now()));
+
+  if (isDev()) {
+    console.log("[Analytics] booking_success event fired", {
+      purchaseId,
+      value: payload.value,
+      currency: payload.currency,
+    });
+  }
+
+  return true;
+};


### PR DESCRIPTION
Booking completes via a wizard step change without a URL change, so GA4 cannot capture it as a page_view conversion. Fire a custom booking_success event with trip route, value and currency from the booking handler, and dedupe per purchase_id via sessionStorage to avoid double-firing on re-renders or repeated clicks.