### PR TITLE
Add roundtrip 15% discount and open-dated return ticket (frontend)

### DIFF
--- a/src/components/purchase/OpenReturnsSection.tsx
+++ b/src/components/purchase/OpenReturnsSection.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import SeatClient from "@/components/SeatClient";
+import { API } from "@/config";
+import { fetchWithInclude } from "@/utils/fetchWithInclude";
+import type {
+  OpenReturnTour,
+  OpenReturnVoucher,
+  OpenReturnStop,
+} from "@/types/purchase";
+
+type Props = {
+  purchaseId: string | number;
+  onActivated: () => void;
+};
+
+const stopName = (stop: OpenReturnVoucher["from_stop"]): string => {
+  if (!stop) return "—";
+  if (typeof stop === "string") return stop;
+  return stop.name ?? "—";
+};
+
+const stopId = (stop: OpenReturnVoucher["from_stop"]): number | null => {
+  if (!stop || typeof stop === "string") return null;
+  const raw = (stop as OpenReturnStop).id;
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : null;
+};
+
+const formatDate = (value: string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("ru-RU", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+};
+
+const formatAmount = (amount: number, currency: string): string =>
+  `${Number(amount).toFixed(2)} ${currency || "₴"}`;
+
+const statusLabel = (status: OpenReturnVoucher["status"]): string => {
+  switch (status) {
+    case "redeemed":
+      return "Использован";
+    case "cancelled":
+      return "Отменён";
+    case "expired":
+      return "Срок истёк";
+    default:
+      return "Активен";
+  }
+};
+
+export default function OpenReturnsSection({ purchaseId, onActivated }: Props) {
+  const [vouchers, setVouchers] = useState<OpenReturnVoucher[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [activeVoucherId, setActiveVoucherId] = useState<string | number | null>(null);
+  const [tours, setTours] = useState<OpenReturnTour[]>([]);
+  const [toursLoading, setToursLoading] = useState(false);
+  const [selectedTourId, setSelectedTourId] = useState<number | null>(null);
+  const [selectedSeats, setSelectedSeats] = useState<number[]>([]);
+  const [activating, setActivating] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const loadVouchers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithInclude(
+        `${API}/public/purchase/${encodeURIComponent(String(purchaseId))}/open-returns`
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as OpenReturnVoucher[];
+      setVouchers(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setVouchers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [purchaseId]);
+
+  useEffect(() => {
+    void loadVouchers();
+  }, [loadVouchers]);
+
+  const resetSelection = useCallback(() => {
+    setActiveVoucherId(null);
+    setTours([]);
+    setSelectedTourId(null);
+    setSelectedSeats([]);
+    setActionError(null);
+  }, []);
+
+  const openPicker = useCallback(
+    async (voucher: OpenReturnVoucher) => {
+      setActiveVoucherId(voucher.id);
+      setTours([]);
+      setSelectedTourId(null);
+      setSelectedSeats([]);
+      setActionError(null);
+      setToursLoading(true);
+      try {
+        const res = await fetchWithInclude(
+          `${API}/public/open-return/${encodeURIComponent(String(voucher.id))}/tours`
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as OpenReturnTour[];
+        setTours(Array.isArray(data) ? data : []);
+      } catch (e) {
+        setActionError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setToursLoading(false);
+      }
+    },
+    []
+  );
+
+  const activeVoucher = useMemo(
+    () => vouchers.find((v) => v.id === activeVoucherId) ?? null,
+    [vouchers, activeVoucherId]
+  );
+  const selectedTour = useMemo(
+    () => tours.find((tour) => tour.tour_id === selectedTourId) ?? null,
+    [tours, selectedTourId]
+  );
+
+  const handleActivate = useCallback(async () => {
+    if (!activeVoucher || selectedTourId == null || selectedSeats.length !== 1) return;
+    setActivating(true);
+    setActionError(null);
+    try {
+      const res = await fetchWithInclude(
+        `${API}/public/open-return/${encodeURIComponent(String(activeVoucher.id))}/activate`,
+        {
+          method: "POST",
+          body: JSON.stringify({ tour_id: selectedTourId, seat_num: selectedSeats[0] }),
+        }
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      resetSelection();
+      await loadVouchers();
+      onActivated();
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setActivating(false);
+    }
+  }, [activeVoucher, selectedTourId, selectedSeats, resetSelection, loadVouchers, onActivated]);
+
+  if (loading) return null;
+  if (!vouchers.length) return null;
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
+      <h3 className="text-lg font-semibold text-slate-900">Открытые обратные билеты</h3>
+      {error ? (
+        <p className="mt-2 text-sm text-rose-600">{error}</p>
+      ) : null}
+      <div className="mt-4 space-y-4">
+        {vouchers.map((voucher) => {
+          const expired =
+            voucher.status === "expired" ||
+            (voucher.status === "open" && new Date(voucher.expires_at).getTime() <= Date.now());
+          const activatable = voucher.status === "open" && !expired;
+          const isActive = voucher.id === activeVoucherId;
+          const depId = stopId(voucher.from_stop);
+          const arrId = stopId(voucher.to_stop);
+
+          return (
+            <div key={voucher.id} className="rounded-xl border border-slate-200 p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="font-semibold text-slate-900">
+                    {stopName(voucher.from_stop)} → {stopName(voucher.to_stop)}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-600">
+                    Оплачено: {formatAmount(voucher.amount_paid, voucher.currency)}
+                  </p>
+                  <p className="text-sm text-slate-600">
+                    Действует до {formatDate(voucher.expires_at)}
+                  </p>
+                </div>
+                <span
+                  className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                    activatable
+                      ? "bg-emerald-50 text-emerald-700"
+                      : "bg-slate-100 text-slate-500"
+                  }`}
+                >
+                  {expired && voucher.status === "open" ? "Срок истёк" : statusLabel(voucher.status)}
+                </span>
+              </div>
+
+              {activatable ? (
+                <div className="mt-3">
+                  {!isActive ? (
+                    <button
+                      type="button"
+                      onClick={() => void openPicker(voucher)}
+                      className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700"
+                    >
+                      Выбрать дату и место
+                    </button>
+                  ) : (
+                    <div className="space-y-3">
+                      {toursLoading ? (
+                        <p className="text-sm text-slate-500">Загрузка рейсов…</p>
+                      ) : tours.length ? (
+                        <div className="flex flex-wrap gap-2">
+                          {tours.map((tour) => (
+                            <button
+                              key={tour.tour_id}
+                              type="button"
+                              onClick={() => {
+                                setSelectedTourId(tour.tour_id);
+                                setSelectedSeats([]);
+                              }}
+                              className={`rounded-lg border px-3 py-2 text-sm ${
+                                tour.tour_id === selectedTourId
+                                  ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+                                  : "border-slate-300 text-slate-700 hover:bg-slate-50"
+                              }`}
+                            >
+                              {formatDate(tour.date)} · {tour.departure_time}–{tour.arrival_time}
+                            </button>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-slate-500">Нет доступных рейсов.</p>
+                      )}
+
+                      {selectedTour && depId != null && arrId != null ? (
+                        <SeatClient
+                          tourId={selectedTour.tour_id}
+                          departureStopId={depId}
+                          arrivalStopId={arrId}
+                          layoutVariant={selectedTour.layout_variant ?? "neoplan"}
+                          selectedSeats={selectedSeats}
+                          maxSeats={1}
+                          onChange={setSelectedSeats}
+                          showExtraBaggage={false}
+                        />
+                      ) : null}
+
+                      {actionError ? (
+                        <p className="text-sm text-rose-600">{actionError}</p>
+                      ) : null}
+
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          disabled={selectedSeats.length !== 1 || activating}
+                          onClick={() => void handleActivate()}
+                          className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {activating ? "Бронируем…" : "Забронировать обратку"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={resetSelection}
+                          className="rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50"
+                        >
+                          Отмена
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/purchase/PurchaseClient.tsx
+++ b/src/components/purchase/PurchaseClient.tsx
@@ -24,6 +24,7 @@ import type {
 } from "@/types/purchase";
 import { fetchWithInclude } from "@/utils/fetchWithInclude";
 import { buildPublicPurchaseEndpoint, buildPublicPurchasePayEndpoint } from "@/utils/publicPurchasePayEndpoint";
+import OpenReturnsSection from "./OpenReturnsSection";
 import {
   normalizePublicPayResponse,
   persistLastLiqPayOrderId,
@@ -2584,6 +2585,8 @@ export default function PurchaseClient({ purchaseId }: PurchaseClientProps) {
         {showReturnTickets
           ? renderTicketSection("Билеты обратно", returnTickets, "tickets:return")
           : null}
+
+        <OpenReturnsSection purchaseId={purchaseId} onActivated={() => void fetchPurchase()} />
 
         {activePanel === "reschedule" ? (
           <section className={`${styles.card} ${styles.panel}`}>

--- a/src/components/search/OrderSummary.tsx
+++ b/src/components/search/OrderSummary.tsx
@@ -17,20 +17,17 @@ type OrderSummaryProps = {
   outboundTour: Tour;
   returnTour: Tour | null;
   returnRequired: boolean;
+  openReturn: boolean;
+  priceLoading: boolean;
   passengerSummaries: PassengerSummary[];
   seatCount: number;
   phone: string;
   email: string;
   totals: {
-    outbound: number;
-    return: number;
-    overall: number;
+    overall: number | null;
     baggage: {
       outboundCount: number;
-      outboundPrice: number;
       returnCount: number;
-      returnPrice: number;
-      total: number;
     };
   };
   formatDateLabel: (value: string) => string;
@@ -44,6 +41,8 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
   outboundTour,
   returnTour,
   returnRequired,
+  openReturn,
+  priceLoading,
   passengerSummaries,
   seatCount,
   phone,
@@ -55,27 +54,12 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
   const contactsProvided = Boolean(phone || email);
   const baggageLines = [
     totals.baggage.outboundCount > 0
-      ? {
-          label: t.baggageSummaryOutbound,
-          count: totals.baggage.outboundCount,
-          price: totals.baggage.outboundPrice,
-          total: totals.baggage.outboundCount * totals.baggage.outboundPrice,
-        }
+      ? { label: t.baggageSummaryOutbound, count: totals.baggage.outboundCount }
       : null,
     totals.baggage.returnCount > 0
-      ? {
-          label: t.baggageSummaryReturn,
-          count: totals.baggage.returnCount,
-          price: totals.baggage.returnPrice,
-          total: totals.baggage.returnCount * totals.baggage.returnPrice,
-        }
+      ? { label: t.baggageSummaryReturn, count: totals.baggage.returnCount }
       : null,
-  ].filter(Boolean) as Array<{
-    label: string;
-    count: number;
-    price: number;
-    total: number;
-  }>;
+  ].filter(Boolean) as Array<{ label: string; count: number }>;
 
   const renderRouteBlock = (
     title: string,
@@ -133,6 +117,18 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
               "bg-indigo-50 text-indigo-700 ring-indigo-100",
             )
           : null}
+
+        {openReturn ? (
+          <div className="rounded-none border-0 bg-slate-50/70 px-3 py-3 shadow-none sm:rounded-xl sm:border sm:border-slate-200 sm:bg-white sm:px-4 sm:py-3 sm:shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              {t.openReturnSummaryLabel}
+            </p>
+            <p className="mt-1 text-base font-semibold text-slate-900">{`${toName} → ${fromName}`}</p>
+            <span className="mt-1 inline-flex items-center gap-2 rounded-full bg-emerald-50 px-2 py-1 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-100">
+              {t.returnDiscountNote}
+            </span>
+          </div>
+        ) : null}
 
         <div className="rounded-none border-0 bg-slate-50/70 px-3 py-3 shadow-none sm:rounded-xl sm:border sm:border-slate-200 sm:bg-white sm:px-4 sm:py-3 sm:shadow-sm">
           <div className="flex items-center justify-between">
@@ -209,7 +205,7 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
               {baggageLines.map((line) => (
                 <div key={line.label} className="flex items-center justify-between gap-3">
                   <span className="text-slate-600">
-                    {line.label}: {line.count} × {formatPrice(line.price)} = {formatPrice(line.total)}
+                    {line.label}: {line.count} ({t.extraBaggagePrice})
                   </span>
                 </div>
               ))}
@@ -220,8 +216,19 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
         <div className="rounded-none border-0 bg-slate-50/70 px-3 py-3 shadow-none sm:rounded-xl sm:border sm:border-slate-200 sm:bg-white sm:px-4 sm:py-4 sm:shadow-sm">
           <div className="flex items-center justify-between text-lg font-semibold text-slate-900">
             <span>{t.total}</span>
-            <span className="text-emerald-600">{formatPrice(totals.overall)}</span>
+            <span className="text-emerald-600">
+              {totals.overall != null
+                ? formatPrice(totals.overall)
+                : priceLoading
+                  ? t.loading
+                  : "—"}
+            </span>
           </div>
+          {(openReturn || returnRequired) && (
+            <p className="mt-1 text-right text-xs font-medium text-emerald-700">
+              {t.returnDiscountNote}
+            </p>
+          )}
         </div>
       </div>
     </aside>

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -47,7 +47,6 @@ type Props = {
   discountCount: number;
 };
 
-const DISCOUNT_RATE = 0.05;
 type StepNavigationItem = {
   id: Step;
   label: string;
@@ -137,6 +136,14 @@ export default function SearchResults({
     null
   );
   const [selectedReturnTour, setSelectedReturnTour] = useState<SearchTour | null>(null);
+
+  // Обратный билет с открытой датой (сценарий C): обратный рейс не выбирается,
+  // бэкенд выпускает предоплаченную открытую обратку (−15%).
+  const [openReturn, setOpenReturn] = useState(false);
+
+  // Итоговая сумма считается на бэкенде (quote), фронт её только отображает.
+  const [quoteAmount, setQuoteAmount] = useState<number | null>(null);
+  const [quoteLoading, setQuoteLoading] = useState(false);
 
   // Выбор мест
   const [selectedOutboundSeats, setSelectedOutboundSeats] = useState<number[]>(
@@ -317,15 +324,15 @@ export default function SearchResults({
   // когда выбран(ы) рейс(ы) — автоматически переходим к шагу 2
   useEffect(() => {
     if (!selectedOutboundTour) return;
-    if (hasReturnSection && !selectedReturnTour) return;
+    if (hasReturnSection && !openReturn && !selectedReturnTour) return;
     // все нужные рейсы выбраны → шаг 2
     setActiveStep((prev) => (prev < 2 ? 2 : prev));
-  }, [selectedOutboundTour, selectedReturnTour, hasReturnSection]);
+  }, [selectedOutboundTour, selectedReturnTour, hasReturnSection, openReturn]);
 
   // ====== ACTIONS: бронь / покупка ======
   const handleAction = async (action: "book" | "purchase") => {
     try {
-      if (!selectedOutboundTour || (returnDate && !selectedReturnTour)) {
+      if (!selectedOutboundTour || (returnDate && !openReturn && !selectedReturnTour)) {
         setMsg("Сначала выберите рейсы");
         setMsgType("error");
         return;
@@ -450,6 +457,8 @@ export default function SearchResults({
         tour_id: selectedOutboundTour.id,
         departure_stop_id: fromId,
         arrival_stop_id: toId,
+        // Сценарий C: выпустить открытую обратку для каждого пассажира.
+        ...(openReturn ? { open_return: true } : {}),
       });
 
       let total = outRes.data.amount_due;
@@ -457,8 +466,8 @@ export default function SearchResults({
       let ticketNumbers = extractTicketNumbers(outRes.data);
       let finalPurchaseResponse = outRes.data;
 
-      // обратно
-      if (selectedReturnTour) {
+      // обратно (конкретная дата) — круговая скидка −15% применяется бэкендом по is_return_leg
+      if (selectedReturnTour && !openReturn) {
         const retRes = await apiClient.post<PublicPurchaseResponse>(`/${endpoint}`, {
           ...basePayload,
           seat_nums: selectedReturnSeats,
@@ -467,6 +476,7 @@ export default function SearchResults({
           departure_stop_id: toId,
           arrival_stop_id: fromId,
           purchase_id: pId,
+          is_return_leg: true,
         });
         total = retRes.data.amount_due;
         pId = Number(retRes.data.purchase_id);
@@ -568,7 +578,7 @@ export default function SearchResults({
           currency: FALLBACK_CURRENCY,
           payment_type: "liqpay",
           passenger_count: safeSeatCount,
-          trip_type: selectedReturnTour ? "roundtrip" : "oneway",
+          trip_type: tripTypeLabel,
         });
         if (typeof window !== "undefined") {
           sessionStorage.setItem("ga_checkout_start_ts", String(Date.now()));
@@ -624,7 +634,7 @@ export default function SearchResults({
         currency: FALLBACK_CURRENCY,
         payment_type: "liqpay",
         passenger_count: safeSeatCount,
-        trip_type: selectedReturnTour ? "roundtrip" : "oneway",
+        trip_type: tripTypeLabel,
       });
       if (typeof window !== "undefined") {
         sessionStorage.setItem("ga_checkout_start_ts", String(Date.now()));
@@ -727,7 +737,12 @@ export default function SearchResults({
 
   // ====== РЕЗЮМЕ ДЛЯ ХЕДЕРОВ ШАГОВ ======
 
-  const returnRequired = Boolean(returnDate && hasReturnSection);
+  const returnRequired = Boolean(returnDate && hasReturnSection && !openReturn);
+  const tripTypeLabel = openReturn
+    ? "open_return"
+    : selectedReturnTour
+      ? "roundtrip"
+      : "oneway";
   const seatsDone =
     selectedOutboundSeats.length === safeSeatCount &&
     (!returnRequired || selectedReturnSeats.length === safeSeatCount);
@@ -834,6 +849,15 @@ export default function SearchResults({
     setActiveStep(1);
   };
 
+  const handleReturnModeChange = (open: boolean) => {
+    setOpenReturn(open);
+    if (open) {
+      setSelectedReturnTour(null);
+      setSelectedReturnSeats([]);
+      setExtraBaggageReturn(Array(safeSeatCount).fill(false));
+    }
+  };
+
   const handleReadyForContacts = () => {
     setActiveStep(3);
   };
@@ -856,17 +880,7 @@ export default function SearchResults({
 
   const formatPrice = useCallback((value: number) => `${value.toFixed(2)} ₴`, []);
 
-  const calculateTotal = useCallback(
-    (tour: SearchTour | null) => {
-      if (!tour) return 0;
-      const adults = Math.max(0, safeSeatCount - safeDiscountCount);
-      const adultSum = adults * tour.price;
-      const discSum = safeDiscountCount * tour.price * (1 - DISCOUNT_RATE);
-      return adultSum + discSum;
-    },
-    [safeDiscountCount, safeSeatCount]
-  );
-
+  // Информационная цена за место багажа (+10%); используется только как подпись в шаге 3.
   const calculateBaggagePrice = useCallback((tour: SearchTour | null) => {
     if (!tour) return null;
 
@@ -874,11 +888,6 @@ export default function SearchResults({
     return Math.round(rawPrice * 100) / 100;
   }, []);
 
-  const outboundTotal = useMemo(
-    () => calculateTotal(selectedOutboundTour),
-    [calculateTotal, selectedOutboundTour]
-  );
-  const returnTotal = useMemo(() => calculateTotal(selectedReturnTour), [calculateTotal, selectedReturnTour]);
   const baggageCounts = useMemo(
     () => ({
       outbound: extraBaggageOutbound.filter(Boolean).length,
@@ -886,33 +895,79 @@ export default function SearchResults({
     }),
     [extraBaggageOutbound, extraBaggageReturn, returnRequired]
   );
-  const baggageTotals = useMemo(() => {
-    const outboundPrice = calculateBaggagePrice(selectedOutboundTour) ?? 0;
-    const returnPrice = calculateBaggagePrice(selectedReturnTour) ?? 0;
-    const outboundTotal = baggageCounts.outbound * outboundPrice;
-    const returnTotal = baggageCounts.return * returnPrice;
 
-    return {
-      outboundCount: baggageCounts.outbound,
-      outboundPrice,
-      returnCount: baggageCounts.return,
-      returnPrice,
-      total: outboundTotal + returnTotal,
+  // Итог считает бэкенд: запрашиваем предварительную сумму (quote) по выбранным ногам.
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!selectedOutboundTour) {
+      setQuoteAmount(null);
+      return;
+    }
+
+    const run = async () => {
+      setQuoteLoading(true);
+      try {
+        const adultCount = safeSeatCount - safeDiscountCount;
+        const legs: Record<string, unknown>[] = [
+          {
+            tour_id: selectedOutboundTour.id,
+            departure_stop_id: fromId,
+            arrival_stop_id: toId,
+            adult_count: adultCount,
+            discount_count: safeDiscountCount,
+            extra_baggage_count: baggageCounts.outbound,
+            ...(openReturn ? { open_return: true } : {}),
+          },
+        ];
+        if (selectedReturnTour && !openReturn) {
+          legs.push({
+            tour_id: selectedReturnTour.id,
+            departure_stop_id: toId,
+            arrival_stop_id: fromId,
+            adult_count: adultCount,
+            discount_count: safeDiscountCount,
+            extra_baggage_count: baggageCounts.return,
+            is_return_leg: true,
+          });
+        }
+
+        let sum = 0;
+        for (const leg of legs) {
+          const res = await apiClient.post<{ amount_due?: unknown }>(
+            "/public/purchase/quote",
+            leg
+          );
+          sum += Number(res.data?.amount_due ?? 0);
+        }
+        if (!cancelled) setQuoteAmount(sum);
+      } catch {
+        if (!cancelled) setQuoteAmount(null);
+      } finally {
+        if (!cancelled) setQuoteLoading(false);
+      }
+    };
+
+    void run();
+    return () => {
+      cancelled = true;
     };
   }, [
     baggageCounts.outbound,
     baggageCounts.return,
-    calculateBaggagePrice,
+    fromId,
+    openReturn,
+    safeDiscountCount,
+    safeSeatCount,
     selectedOutboundTour,
     selectedReturnTour,
+    toId,
   ]);
-  const overallTotal = useMemo(
-    () => outboundTotal + returnTotal + baggageTotals.total,
-    [baggageTotals.total, outboundTotal, returnTotal]
-  );
+
+  const overallTotal = quoteAmount ?? 0;
 
   const buildCheckoutItems = useCallback(() => {
-    const tripType = selectedReturnTour ? "roundtrip" : "oneway";
+    const tripType = openReturn ? "open_return" : selectedReturnTour ? "roundtrip" : "oneway";
     const route = buildRouteCategory(
       { id: fromId, name: fromName },
       { id: toId, name: toName },
@@ -944,6 +999,7 @@ export default function SearchResults({
   }, [
     fromId,
     fromName,
+    openReturn,
     safeSeatCount,
     selectedOutboundTour,
     selectedReturnTour,
@@ -955,7 +1011,7 @@ export default function SearchResults({
   useEffect(() => {
     if (activeStep !== 2) return;
     if (!selectedOutboundTour) return;
-    if (returnDate && !selectedReturnTour) return;
+    if (returnDate && !openReturn && !selectedReturnTour) return;
     if (viewItemFiredRef.current) return;
     viewItemFiredRef.current = true;
     const { items, tripType, route } = buildCheckoutItems();
@@ -970,6 +1026,7 @@ export default function SearchResults({
   }, [
     activeStep,
     buildCheckoutItems,
+    openReturn,
     overallTotal,
     returnDate,
     safeSeatCount,
@@ -1025,12 +1082,13 @@ export default function SearchResults({
 
   const orderSummaryTotals = useMemo(
     () => ({
-      outbound: outboundTotal,
-      return: returnTotal,
-      overall: overallTotal,
-      baggage: baggageTotals,
+      overall: quoteAmount,
+      baggage: {
+        outboundCount: baggageCounts.outbound,
+        returnCount: baggageCounts.return,
+      },
     }),
-    [baggageTotals, outboundTotal, overallTotal, returnTotal]
+    [quoteAmount, baggageCounts.outbound, baggageCounts.return]
   );
   const showStepNavigation = Boolean(selectedOutboundTour);
   const stepCounterLabel = t.stepCounter(activeStep, stepNavigation.length);
@@ -1085,6 +1143,39 @@ export default function SearchResults({
               discountCount={safeDiscountCount}
               t={t}
             />
+          )}
+
+          {returnDate && selectedOutboundTour && (
+            <div className="space-y-2 rounded-xl border border-slate-200 bg-slate-50 p-3 sm:p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                {t.returnModeTitle}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleReturnModeChange(false)}
+                  className={`rounded-lg border px-3 py-2 text-sm ${
+                    !openReturn
+                      ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+                      : "border-slate-300 text-slate-700 hover:bg-slate-100"
+                  }`}
+                >
+                  {t.returnModeFixed}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleReturnModeChange(true)}
+                  className={`rounded-lg border px-3 py-2 text-sm ${
+                    openReturn
+                      ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+                      : "border-slate-300 text-slate-700 hover:bg-slate-100"
+                  }`}
+                >
+                  {t.returnModeOpen}
+                </button>
+              </div>
+              {openReturn && <p className="text-xs text-slate-600">{t.openReturnHint}</p>}
+            </div>
           )}
 
           {returnListVisible && (
@@ -1286,6 +1377,8 @@ export default function SearchResults({
               outboundTour={selectedOutboundTour as SearchTour}
               returnTour={selectedReturnTour}
               returnRequired={returnRequired}
+              openReturn={openReturn}
+              priceLoading={quoteLoading}
               passengerSummaries={passengerSummaries}
               seatCount={seatCount}
               phone={phone}

--- a/src/components/search/searchDictionary.ts
+++ b/src/components/search/searchDictionary.ts
@@ -117,6 +117,13 @@ const dict: Record<Lang, Dict> = {
     removeBagAria: "Убрать багаж",
     baggageSummaryOutbound: "Доп. багаж (Туда)",
     baggageSummaryReturn: "Доп. багаж (Обратно)",
+    returnModeTitle: "Обратный билет",
+    returnModeFixed: "Конкретная дата",
+    returnModeOpen: "Открытая дата (−15%)",
+    openReturnHint:
+      "Дату и место обратного рейса вы выберете позже в личном кабинете по QR-коду.",
+    openReturnSummaryLabel: "Обратно (открытая дата)",
+    returnDiscountNote: "обратка −15%",
   },
   en: {
     noResults: "No trips found",
@@ -232,6 +239,13 @@ const dict: Record<Lang, Dict> = {
     removeBagAria: "Remove bag",
     baggageSummaryOutbound: "Extra baggage (Outbound)",
     baggageSummaryReturn: "Extra baggage (Return)",
+    returnModeTitle: "Return ticket",
+    returnModeFixed: "Fixed date",
+    returnModeOpen: "Open date (−15%)",
+    openReturnHint:
+      "You will choose the return date and seat later in your account via the QR code.",
+    openReturnSummaryLabel: "Return (open date)",
+    returnDiscountNote: "return −15%",
   },
   bg: {
     noResults: "Няма намерени курсове",
@@ -348,6 +362,13 @@ const dict: Record<Lang, Dict> = {
     removeBagAria: "Премахни багаж",
     baggageSummaryOutbound: "Доп. багаж (Натам)",
     baggageSummaryReturn: "Доп. багаж (Обратно)",
+    returnModeTitle: "Обратен билет",
+    returnModeFixed: "Конкретна дата",
+    returnModeOpen: "Отворена дата (−15%)",
+    openReturnHint:
+      "Датата и мястото за обратния курс ще изберете по-късно в профила си чрез QR кода.",
+    openReturnSummaryLabel: "Обратно (отворена дата)",
+    returnDiscountNote: "обратно −15%",
   },
   ua: {
     noResults: "Рейси не знайдено",
@@ -464,6 +485,13 @@ const dict: Record<Lang, Dict> = {
     removeBagAria: "Прибрати багаж",
     baggageSummaryOutbound: "Додатковий багаж (Туди)",
     baggageSummaryReturn: "Додатковий багаж (Назад)",
+    returnModeTitle: "Зворотний квиток",
+    returnModeFixed: "Конкретна дата",
+    returnModeOpen: "Відкрита дата (−15%)",
+    openReturnHint:
+      "Дату та місце зворотного рейсу ви оберете пізніше в особистому кабінеті за QR-кодом.",
+    openReturnSummaryLabel: "Назад (відкрита дата)",
+    returnDiscountNote: "зворотний −15%",
   },
 };
 

--- a/src/components/search/types.ts
+++ b/src/components/search/types.ts
@@ -125,4 +125,10 @@ export type Dict = {
   removeBagAria: string;
   baggageSummaryOutbound: string;
   baggageSummaryReturn: string;
+  returnModeTitle: string;
+  returnModeFixed: string;
+  returnModeOpen: string;
+  openReturnHint: string;
+  openReturnSummaryLabel: string;
+  returnDiscountNote: string;
 };

--- a/src/types/purchase.ts
+++ b/src/types/purchase.ts
@@ -125,6 +125,43 @@ export type CancelPreview = {
   currency: string;
 };
 
+export type OpenReturnStatus = "open" | "redeemed" | "cancelled" | "expired";
+
+export type OpenReturnStop = {
+  id?: number | string | null;
+  name?: string | null;
+};
+
+export type OpenReturnVoucher = {
+  id: number | string;
+  from_stop: OpenReturnStop | string | null;
+  to_stop: OpenReturnStop | string | null;
+  amount_paid: number;
+  currency: string;
+  expires_at: string;
+  status: OpenReturnStatus;
+};
+
+export type OpenReturnSeat = {
+  seat_id: number;
+  seat_num: number;
+  status: "available" | "occupied" | "blocked";
+};
+
+export type OpenReturnTour = {
+  tour_id: number;
+  date: string;
+  departure_time: string;
+  arrival_time: string;
+  layout_variant?: string | null;
+  seats?: OpenReturnSeat[];
+};
+
+export type OpenReturnActivateResponse = {
+  ticket_id: number | string;
+  deep_link?: string | null;
+};
+
 export type BaggageQuote = {
   can_apply: boolean;
   delta: number;


### PR DESCRIPTION
Send is_return_leg on the return-leg purchase and open_return on the outbound purchase so the backend applies the 15% roundtrip discount and issues a prepaid open-dated return. Stop computing prices on the client: the order total now comes from a backend quote, and the summary shows the "-15%" return label. Add an "Открытые обратные билеты" section to the minicabinet (PurchaseClient) to pick a date/seat and activate the prepaid return via the new /public/open-return endpoints.

https://claude.ai/code/session_01UNgZjAFMEU7MdmQXDbUSr8