### PR TITLE
Круговая скидка 15% и обратный билет с открытой датой

### DIFF
--- a/src/components/booking/BookingFlow.tsx
+++ b/src/components/booking/BookingFlow.tsx
@@ -20,6 +20,7 @@ export type Criteria = {
   toName: string;
   date: string;
   returnDate?: string;
+  openReturn?: boolean;
   seatCount: number;
   discountCount: number;
 };

--- a/src/components/hero/DateInput.tsx
+++ b/src/components/hero/DateInput.tsx
@@ -12,6 +12,7 @@ type Props = {
   label?: string;                 // 🔹 подпись внутри пилюли: "Date" / "Return"
   lang?: "ru" | "bg" | "en" | "ua";
   onOpen?: () => void;            // если календарь внешне открывается
+  displayText?: string;          // переопределяет показываемое значение (напр. «Открытая дата»)
 };
 
 export default function DateInput({
@@ -23,9 +24,10 @@ export default function DateInput({
   label,
   lang = "ru", // eslint-disable-line @typescript-eslint/no-unused-vars
   onOpen,
+  displayText,
 }: Props) {
   // отображаемое значение (если пусто — покажем "— — —")
-  const human = value ? formatDate(value) : "— — —";
+  const human = displayText ?? (value ? formatDate(value) : "— — —");
 
   return (
     <button

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -29,6 +29,7 @@ type Props = {
     toName: string;
     date: string;
     returnDate?: string;
+    openReturn?: boolean;
     seatCount: number;
     discountCount: number;
   }) => void;
@@ -43,6 +44,8 @@ const L = {
     search: 'Поиск',
     swapTitle: 'Поменять местами',
     noMatches: 'Ничего не найдено',
+    openDate: 'Открытая дата',
+    openDateBtn: 'Билет с открытой датой',
   },
   en: {
     from: 'From',
@@ -52,6 +55,8 @@ const L = {
     search: 'Search',
     swapTitle: 'Swap',
     noMatches: 'No matches',
+    openDate: 'Open date',
+    openDateBtn: 'Open-date ticket',
   },
   bg: {
     from: 'Откъде',
@@ -61,6 +66,8 @@ const L = {
     search: 'Търсене',
     swapTitle: 'Размени',
     noMatches: 'Няма съвпадения',
+    openDate: 'Отворена дата',
+    openDateBtn: 'Билет с отворена дата',
   },
   ua: {
     from: 'Звідки',
@@ -70,6 +77,8 @@ const L = {
     search: 'Пошук',
     swapTitle: 'Поміняти місцями',
     noMatches: 'Нічого не знайдено',
+    openDate: 'Відкрита дата',
+    openDateBtn: 'Квиток з відкритою датою',
   },
 };
 
@@ -95,6 +104,8 @@ export default function SearchForm({
   const [returnDate, setReturnDate] = useState<string>(
     initialReturnDate ?? '',
   );
+  // Обратный билет с открытой датой (выбирается из календаря «Обратно»)
+  const [openReturn, setOpenReturn] = useState(false);
   const [passengers, setPassengers] = useState({
     adults: Math.max(1, initialSeats),
     discount: 0,
@@ -195,6 +206,13 @@ export default function SearchForm({
     setTo(from);
     setDepartDate('');
     setReturnDate('');
+    setOpenReturn(false);
+  };
+
+  const handleSelectOpenReturn = () => {
+    setOpenReturn(true);
+    setReturnDate('');
+    setShowReturn(false);
   };
 
   const handleDepartOpen = () => setShowDepart(true);
@@ -221,7 +239,7 @@ export default function SearchForm({
       ),
       departure_date: departDate,
       return_date: returnDate || undefined,
-      trip_type: returnDate ? 'roundtrip' : 'oneway',
+      trip_type: openReturn ? 'open_return' : returnDate ? 'roundtrip' : 'oneway',
       passenger_count: passengers.adults + passengers.discount,
       adult_count: passengers.adults,
       discount_count: passengers.discount,
@@ -232,7 +250,8 @@ export default function SearchForm({
       fromName,
       toName,
       date: departDate,
-      returnDate: returnDate || undefined,
+      returnDate: openReturn ? undefined : returnDate || undefined,
+      openReturn,
       seatCount,
       discountCount: passengers.discount,
     });
@@ -318,6 +337,7 @@ export default function SearchForm({
           lang={lang}
           disabled={!fromId || !toId}
           onOpen={handleReturnOpen}
+          displayText={openReturn ? t.openDate : undefined}
         />
 
         <PassengersInput
@@ -417,10 +437,20 @@ export default function SearchForm({
               selectedDate={returnDate}
               onSelect={(iso) => {
                 setReturnDate(iso);
+                setOpenReturn(false);
                 setShowReturn(false);
               }}
               lang={lang}
             />
+            <div className="px-3 pb-3">
+              <button
+                type="button"
+                onClick={handleSelectOpenReturn}
+                className="w-full rounded-xl border border-emerald-500 px-4 py-2.5 text-sm font-semibold text-emerald-700 transition hover:bg-emerald-50"
+              >
+                {t.openDateBtn}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -43,6 +43,7 @@ type Props = {
   toName: string;
   date: string;
   returnDate?: string;
+  openReturn?: boolean;
   seatCount: number;
   discountCount: number;
 };
@@ -99,6 +100,7 @@ export default function SearchResults({
   toName,
   date,
   returnDate,
+  openReturn: openReturnInitial = false,
   seatCount,
   discountCount,
 }: Props) {
@@ -139,7 +141,7 @@ export default function SearchResults({
 
   // Обратный билет с открытой датой (сценарий C): обратный рейс не выбирается,
   // бэкенд выпускает предоплаченную открытую обратку (−15%).
-  const [openReturn, setOpenReturn] = useState(false);
+  const [openReturn, setOpenReturn] = useState(Boolean(openReturnInitial));
 
   // Итоговая сумма считается на бэкенде (quote), фронт её только отображает.
   const [quoteAmount, setQuoteAmount] = useState<number | null>(null);
@@ -1145,35 +1147,42 @@ export default function SearchResults({
             />
           )}
 
-          {returnDate && selectedOutboundTour && (
+          {(returnDate || openReturn) && selectedOutboundTour && (
             <div className="space-y-2 rounded-xl border border-slate-200 bg-slate-50 p-3 sm:p-4">
               <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                 {t.returnModeTitle}
               </p>
-              <div className="flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={() => handleReturnModeChange(false)}
-                  className={`rounded-lg border px-3 py-2 text-sm ${
-                    !openReturn
-                      ? "border-emerald-500 bg-emerald-50 text-emerald-700"
-                      : "border-slate-300 text-slate-700 hover:bg-slate-100"
-                  }`}
-                >
-                  {t.returnModeFixed}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handleReturnModeChange(true)}
-                  className={`rounded-lg border px-3 py-2 text-sm ${
-                    openReturn
-                      ? "border-emerald-500 bg-emerald-50 text-emerald-700"
-                      : "border-slate-300 text-slate-700 hover:bg-slate-100"
-                  }`}
-                >
-                  {t.returnModeOpen}
-                </button>
-              </div>
+              {returnDate && (
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleReturnModeChange(false)}
+                    className={`rounded-lg border px-3 py-2 text-sm ${
+                      !openReturn
+                        ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+                        : "border-slate-300 text-slate-700 hover:bg-slate-100"
+                    }`}
+                  >
+                    {t.returnModeFixed}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleReturnModeChange(true)}
+                    className={`rounded-lg border px-3 py-2 text-sm ${
+                      openReturn
+                        ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+                        : "border-slate-300 text-slate-700 hover:bg-slate-100"
+                    }`}
+                  >
+                    {t.returnModeOpen}
+                  </button>
+                </div>
+              )}
+              {openReturn && (
+                <p className="text-xs text-slate-600">
+                  {t.openReturnSummaryLabel} · {t.returnDiscountNote}
+                </p>
+              )}
               {openReturn && <p className="text-xs text-slate-600">{t.openReturnHint}</p>}
             </div>
           )}


### PR DESCRIPTION
## Summary

Фронтенд для трёх сценариев покупки и активации открытой обратки в миникабинете. Цены считает бэкенд — фронт их только отображает.

- **A. В одну сторону** — без изменений.
- **B. Туда-обратно с датой** — второй (обратный) POST шлёт `is_return_leg: true`, бэкенд применяет −15%.
- **C. Туда + обратка с открытой датой** — в календаре «Обратно» появилась кнопка **«Билет с открытой датой»**; при выборе обратный рейс не выбирается, в первый POST уходит `open_return: true`, бэкенд выпускает предоплаченную открытую обратку (−15%).
- **Миникабинет** (`/cabinet`, `/q/[opaque]`) — новый раздел «Открытые обратные билеты»: список ваучеров → выбор рейса и места → активация без доплаты.

## Что изменено
- `hero/SearchForm.tsx`, `hero/DateInput.tsx` — кнопка «открытая дата» в календаре обратки + показ «Открытая дата».
- `booking/BookingFlow.tsx` — проброс флага `openReturn`.
- `search/SearchResults.tsx` — флаги `is_return_leg`/`open_return`, переключатель режима обратки, удалён локальный расчёт цены (5% `DISCOUNT_RATE`), итог из бэкенд-quote.
- `search/OrderSummary.tsx` — блок «Обратно (открытая дата)» и подпись «−15%», итог из бэкенда.
- `purchase/OpenReturnsSection.tsx` (новый) + `purchase/PurchaseClient.tsx` — активация открытой обратки.
- `types/purchase.ts`, `search/types.ts`, `search/searchDictionary.ts` — типы и строки (ru/en/bg/ua).

## Зависимость от бэкенда (отдельный репозиторий)
Фронт уже вызывает; эти ручки нужно реализовать:
- `POST /public/purchase/quote` → `{ amount_due, currency }`
- флаги `is_return_leg` / `open_return` в `/book` и `/public/purchase`
- `GET /public/purchase/{id}/open-returns`
- `GET /public/open-return/{id}/tours`
- `POST /public/open-return/{id}/activate` → `{ ticket_id, deep_link }`
- новая таблица `open_ticket`, срок 3 мес., скидки перемножаются (`base × 0.95 × 0.85`)

Пока ручек нет: итог в сводке показывается как «—» до оформления, финальная сумма берётся из ответа на покупку.

## Test plan
- [x] `npm run build` — успешно (вкл. TypeScript)
- [x] `eslint` — без ошибок
- [ ] E2E после готовности бэкенда: сценарии A/B/C, активация открытой обратки в миникабинете, проверка просроченного ваучера

https://claude.ai/code/session_01UNgZjAFMEU7MdmQXDbUSr8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNgZjAFMEU7MdmQXDbUSr8)_