### PR TITLE
Preserve last search params when returning to search form

### DIFF
--- a/src/components/booking/BookingFlow.tsx
+++ b/src/components/booking/BookingFlow.tsx
@@ -33,6 +33,8 @@ type BookingFlowProps = {
 export default function BookingFlow({ forcedFromId, forcedToId }: BookingFlowProps = {}) {
   const { lang } = useLanguage();
   const [criteria, setCriteria] = useState<Criteria | null>(null);
+  // запоминаем последний поиск, чтобы при возврате форма не была пустой
+  const [lastCriteria, setLastCriteria] = useState<Criteria | null>(null);
   const resultsRef = useRef<HTMLDivElement | null>(null);
 
   // после нового поиска скроллим к заголовку результатов с небольшим отступом
@@ -60,9 +62,21 @@ export default function BookingFlow({ forcedFromId, forcedToId }: BookingFlowPro
           <SearchForm
             lang={lang}
             embedded
-            initialFromId={forcedFromId}
-            initialToId={forcedToId}
-            onSearch={(params) => setCriteria(params)}
+            initialFromId={forcedFromId ?? lastCriteria?.from}
+            initialToId={forcedToId ?? lastCriteria?.to}
+            initialDate={lastCriteria?.date}
+            initialReturnDate={lastCriteria?.returnDate}
+            initialSeats={
+              lastCriteria
+                ? lastCriteria.seatCount - lastCriteria.discountCount
+                : undefined
+            }
+            initialDiscount={lastCriteria?.discountCount}
+            initialOpenReturn={lastCriteria?.openReturn}
+            onSearch={(params) => {
+              setCriteria(params);
+              setLastCriteria(params);
+            }}
           />
         </div>
       )}

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -21,6 +21,8 @@ type Props = {
   initialDate?: string;       // YYYY-MM-DD
   initialReturnDate?: string; // YYYY-MM-DD
   initialSeats?: number;
+  initialDiscount?: number;
+  initialOpenReturn?: boolean;
   embedded?: boolean;
   onSearch: (params: {
     from: string;
@@ -89,6 +91,8 @@ export default function SearchForm({
   initialDate,
   initialReturnDate,
   initialSeats = 1,
+  initialDiscount = 0,
+  initialOpenReturn = false,
   embedded = false,
   onSearch,
 }: Props) {
@@ -105,10 +109,10 @@ export default function SearchForm({
     initialReturnDate ?? '',
   );
   // Обратный билет с открытой датой (выбирается из календаря «Обратно»)
-  const [openReturn, setOpenReturn] = useState(false);
+  const [openReturn, setOpenReturn] = useState(initialOpenReturn);
   const [passengers, setPassengers] = useState({
     adults: Math.max(1, initialSeats),
-    discount: 0,
+    discount: Math.max(0, initialDiscount),
   });
   const seatCount = passengers.adults + passengers.discount;
 


### PR DESCRIPTION
Remember the last submitted search criteria in BookingFlow so that clicking "Назад к поиску" restores the form fields (from/to cities, dates, passengers, open-return) instead of showing an empty form.

https://claude.ai/code/session_01LtQKrkwUDYeSqGD1SZbQZM