### PR TITLE
Polish Russian wording for return ticket UI

### DIFF
--- a/src/components/purchase/OpenReturnsSection.tsx
+++ b/src/components/purchase/OpenReturnsSection.tsx
@@ -260,7 +260,7 @@ export default function OpenReturnsSection({ purchaseId, onActivated }: Props) {
                           onClick={() => void handleActivate()}
                           className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
                         >
-                          {activating ? "Бронируем…" : "Забронировать обратку"}
+                          {activating ? "Бронируем…" : "Забронировать обратный билет"}
                         </button>
                         <button
                           type="button"

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -140,7 +140,7 @@ export default function SearchResults({
   const [selectedReturnTour, setSelectedReturnTour] = useState<SearchTour | null>(null);
 
   // Обратный билет с открытой датой (сценарий C): обратный рейс не выбирается,
-  // бэкенд выпускает предоплаченную открытую обратку (−15%).
+  // бэкенд выпускает предоплаченный открытый обратный билет (−15%).
   const [openReturn, setOpenReturn] = useState(Boolean(openReturnInitial));
 
   // Итоговая сумма считается на бэкенде (quote), фронт её только отображает.

--- a/src/components/search/searchDictionary.ts
+++ b/src/components/search/searchDictionary.ts
@@ -123,7 +123,7 @@ const dict: Record<Lang, Dict> = {
     openReturnHint:
       "Дату и место обратного рейса вы выберете позже в личном кабинете по QR-коду.",
     openReturnSummaryLabel: "Обратно (открытая дата)",
-    returnDiscountNote: "обратка −15%",
+    returnDiscountNote: "обратный −15%",
   },
   en: {
     noResults: "No trips found",


### PR DESCRIPTION
### Motivation
- Replace informal/colloquial Russian phrasing around return tickets/discounts with a more formal, consistent wording for UX clarity.

### Description
- Change the Russian discount label from `"обратка −15%"` to `"обратный −15%"` in `src/components/search/searchDictionary.ts`.
- Update the open-return booking button text from `"Забронировать обратку"` to `"Забронировать обратный билет"` in `src/components/purchase/OpenReturnsSection.tsx`.
- Align the inline comment wording about open returns in `src/components/search/SearchResults.tsx` to use `"открытый обратный билет"`.

### Testing
- Ran `npm run test:build && node --test .tmp-tests/utils/passengerContact.test.js .tmp-tests/lib/analytics.test.js` and the compiled tests passed (20/20).
- Running `npm test` currently fails due to the package `test` script referencing a different compiled test path than produced by `test:build` and therefore did not complete successfully.
- Running `npm run lint` (`next lint`) failed with `Invalid project directory provided` in this environment and did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1842a04f2c8327b2cb9d99640a10c9)