### PR TITLE
Clarify return ticket discount copy

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -140,7 +140,8 @@ export default function SearchResults({
   const [selectedReturnTour, setSelectedReturnTour] = useState<SearchTour | null>(null);
 
   // Обратный билет с открытой датой (сценарий C): обратный рейс не выбирается,
-  // бэкенд выпускает предоплаченный открытый обратный билет (−15%).
+  // бэкенд выпускает предоплаченный открытый обратный билет.
+  // Скидка −15% относится к обратному билету при покупке туда-обратно.
   const [openReturn, setOpenReturn] = useState(Boolean(openReturnInitial));
 
   // Итоговая сумма считается на бэкенде (quote), фронт её только отображает.
@@ -460,6 +461,7 @@ export default function SearchResults({
         departure_stop_id: fromId,
         arrival_stop_id: toId,
         // Сценарий C: выпустить открытую обратку для каждого пассажира.
+        // Скидка применяется к обратному билету, а не к открытому формату даты.
         ...(openReturn ? { open_return: true } : {}),
       });
 
@@ -468,7 +470,7 @@ export default function SearchResults({
       let ticketNumbers = extractTicketNumbers(outRes.data);
       let finalPurchaseResponse = outRes.data;
 
-      // обратно (конкретная дата) — круговая скидка −15% применяется бэкендом по is_return_leg
+      // обратно (конкретная дата) — скидка −15% на обратный билет применяется бэкендом по is_return_leg
       if (selectedReturnTour && !openReturn) {
         const retRes = await apiClient.post<PublicPurchaseResponse>(`/${endpoint}`, {
           ...basePayload,

--- a/src/components/search/searchDictionary.ts
+++ b/src/components/search/searchDictionary.ts
@@ -119,11 +119,11 @@ const dict: Record<Lang, Dict> = {
     baggageSummaryReturn: "Доп. багаж (Обратно)",
     returnModeTitle: "Обратный билет",
     returnModeFixed: "Конкретная дата",
-    returnModeOpen: "Открытая дата (−15%)",
+    returnModeOpen: "Открытая дата",
     openReturnHint:
       "Дату и место обратного рейса вы выберете позже в личном кабинете по QR-коду.",
     openReturnSummaryLabel: "Обратно (открытая дата)",
-    returnDiscountNote: "обратный −15%",
+    returnDiscountNote: "−15% на обратный билет при покупке туда-обратно",
   },
   en: {
     noResults: "No trips found",
@@ -241,11 +241,11 @@ const dict: Record<Lang, Dict> = {
     baggageSummaryReturn: "Extra baggage (Return)",
     returnModeTitle: "Return ticket",
     returnModeFixed: "Fixed date",
-    returnModeOpen: "Open date (−15%)",
+    returnModeOpen: "Open date",
     openReturnHint:
       "You will choose the return date and seat later in your account via the QR code.",
     openReturnSummaryLabel: "Return (open date)",
-    returnDiscountNote: "return −15%",
+    returnDiscountNote: "15% off the return ticket with a round trip",
   },
   bg: {
     noResults: "Няма намерени курсове",
@@ -364,11 +364,11 @@ const dict: Record<Lang, Dict> = {
     baggageSummaryReturn: "Доп. багаж (Обратно)",
     returnModeTitle: "Обратен билет",
     returnModeFixed: "Конкретна дата",
-    returnModeOpen: "Отворена дата (−15%)",
+    returnModeOpen: "Отворена дата",
     openReturnHint:
       "Датата и мястото за обратния курс ще изберете по-късно в профила си чрез QR кода.",
     openReturnSummaryLabel: "Обратно (отворена дата)",
-    returnDiscountNote: "обратно −15%",
+    returnDiscountNote: "−15% за обратния билет при двупосочно пътуване",
   },
   ua: {
     noResults: "Рейси не знайдено",
@@ -487,11 +487,11 @@ const dict: Record<Lang, Dict> = {
     baggageSummaryReturn: "Додатковий багаж (Назад)",
     returnModeTitle: "Зворотний квиток",
     returnModeFixed: "Конкретна дата",
-    returnModeOpen: "Відкрита дата (−15%)",
+    returnModeOpen: "Відкрита дата",
     openReturnHint:
       "Дату та місце зворотного рейсу ви оберете пізніше в особистому кабінеті за QR-кодом.",
     openReturnSummaryLabel: "Назад (відкрита дата)",
-    returnDiscountNote: "зворотний −15%",
+    returnDiscountNote: "−15% на зворотний квиток при купівлі туди й назад",
   },
 };
 


### PR DESCRIPTION
### Motivation
- Пользователи могли воспринять знак `−15%` в метке «Открытая дата (−15%)` как скидку за именно открытый формат даты, тогда как скидка применяется к обратному билету при покупке туда-обратно.
- Нужно исправить текст в UI и комментариях, чтобы явно разграничить формат «открытая дата» и скидку за обратный билет при двусторонней покупке.

### Description
- Обновлён словарь локализаций в `src/components/search/searchDictionary.ts`, где убран `−15%` из `returnModeOpen` в нескольких языках и изменён текст `returnDiscountNote` на формулировку, что `−15%` применяется на обратный билет при покупке туда-обратно (включая RU/EN/BG/UA).
- Обновлены поясняющие комментарии в `src/components/search/SearchResults.tsx`, добавлено уточнение, что скидка относится к обратному билету, а не к открытому формату даты.
- UI использует те же ключи словаря (`t.returnModeOpen`, `t.returnDiscountNote`), только изменён текст локализаций, поэтому поведение бизнес-логики не менялось.

### Testing
- Запуск сборки `npm run build` прошёл успешно. 
- TypeScript сборка тестов `npm run test:build` выполнилась успешно. 
- Юнит-тесты `node --test .tmp-tests/utils/passengerContact.test.js .tmp-tests/lib/analytics.test.js` прошли успешно (20 тестов, 0 падений). 
- `npm run lint` завершился с ошибкой из-за конфигурации `next lint` в этой среде, и поэтому прогон линтера не прошёл.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a184619a2ac832784264bdfd636e27a)