### PR TITLE
seo: deindex BG locale (noindex meta + exclude from sitemap)

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,6 +20,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
   homeLanguages["x-default"] = buildUrl(DEFAULT_LOCALE, "/");
 
   for (const locale of LOCALES) {
+    // BG version is intentionally excluded from the sitemap (noindex).
+    // It stays reachable via direct link and manual language switch,
+    // and remains listed as an hreflang alternate above.
+    if (locale === "bg") continue;
     entries.push({
       url: buildUrl(locale, "/"),
       lastModified: now,
@@ -41,6 +45,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
     const priority = key === "route" ? 0.9 : key.startsWith("odessa-") ? 0.9 : 0.7;
 
     for (const locale of LOCALES) {
+      // BG trip pages are excluded from the sitemap (noindex), but stay
+      // listed as hreflang alternates above.
+      if (locale === "bg") continue;
       const slug = trip.i18n[locale as Lang]?.slug;
       if (!slug) continue;
       entries.push({

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -111,6 +111,7 @@ export function buildHomeMetadata(locale: Lang): Metadata {
     title: meta.title,
     description: meta.description,
     alternates,
+    ...(locale === "bg" ? { robots: { index: false, follow: true } } : {}),
     openGraph: {
       title: meta.title,
       description: meta.description,
@@ -140,6 +141,7 @@ export function buildTripMetadata(tripKey: string, locale: Lang): Metadata | nul
     title: data.title,
     description: data.description,
     alternates,
+    ...(locale === "bg" ? { robots: { index: false, follow: true } } : {}),
     openGraph: {
       title: data.title,
       description: data.description,


### PR DESCRIPTION
- BG home and trip pages now emit <meta name="robots" content="noindex, follow"> via robots: { index: false, follow: true } in metadata builders. RU/UA/EN are unchanged.
- app/sitemap.ts no longer emits /bg/ URL entries (56 -> 42 URLs). BG remains listed as an hreflang alternate, so hreflang config is unchanged.
- Language switcher and direct links to /bg/ pages keep working.

https://claude.ai/code/session_01Ek73epuCXatiVooJnBa48s