### PR TITLE
Always send ticket_ids when cancelling via minicabinet

### DIFF
--- a/src/components/purchase/PurchaseClient.tsx
+++ b/src/components/purchase/PurchaseClient.tsx
@@ -1659,7 +1659,11 @@ export default function PurchaseClient({ purchaseId }: PurchaseClientProps) {
     const identifiers = toOriginalTicketIds(cancelTickets);
     const body: Record<string, unknown> = {};
 
-    if (identifiers.length > 0 && cancelTickets.length !== allTicketIds.length) {
+    // The backend requires an explicit, non-empty ticket_ids list (it has no
+    // "empty means everything" shortcut). Always send the selected tickets,
+    // including when cancelling the whole booking — otherwise the request is
+    // rejected with 422 and the seats are never released.
+    if (identifiers.length > 0) {
       body.ticket_ids = identifiers;
     }
 
@@ -1697,7 +1701,6 @@ export default function PurchaseClient({ purchaseId }: PurchaseClientProps) {
       setActionLoading(null);
     }
   }, [
-    allTicketIds,
     cancelPreview,
     cancelSelectionCount,
     cancelTickets,


### PR DESCRIPTION
When the customer cancelled the entire booking the request body omitted ticket_ids, but the backend CancelRequest requires a non-empty list, so the cancel was rejected with 422 and the seats were never released.

Always send the explicit selected ticket ids, including the full-booking case.

https://claude.ai/code/session_01Csuigndj86839SyqeKGuZN