### PR TITLE
Refactor GA4 analytics: centralize ecommerce funnel & add currency by locale

### DIFF
--- a/docs/analytics-events.md
+++ b/docs/analytics-events.md
@@ -1,0 +1,231 @@
+# Аналитика GA4 — карта событий, CHANGELOG и верификация
+
+Централизация слоя аналитики. Все вызовы GA4 идут через типизированные хелперы
+в `src/lib/analytics.ts`. Голых `window.gtag?.()` в компонентах не осталось —
+поэтому UTM-атрибуция (прикрепляется в `trackEvent`) теперь попадает во **все**
+события.
+
+- **Валюта по локали:** `getCurrencyForLocale(locale)` → `UAH` для `ru`/`ua`,
+  `EUR` для `en`/`bg`. Жёсткая константа `FALLBACK_CURRENCY = "UAH"` удалена;
+  валюта везде выводится из локали.
+- **`value`** во всех событиях воронки — в основных единицах валюты (гривны/евро,
+  не копейки/центы).
+- **Единый `items[]`** через всю воронку (item_id `<departure>-<arrival>` там, где
+  применимо; item_name — читаемое направление; price, quantity).
+
+---
+
+## CHANGELOG (действие → было → стало)
+
+| Действие человека | Было (событие) | Стало (событие) | Где |
+| --- | --- | --- | --- |
+| Клик «Поиск» | `form_submit` + `search` | `search` (form_submit удалён) | `SearchForm.tsx`, `BookingPanel.tsx` |
+| Отрисован список рейсов | — | `view_item_list` (новое) | `SearchResults.tsx` |
+| Клик по рейсу | `select_item` | `select_item` (без изменений) | `SearchResults.tsx` |
+| Место выбрано (рейс+место) | `view_item` | `add_to_cart` (переименовано) | `SearchResults.tsx` |
+| Экран оформления открыт | `purchase_click` + `begin_checkout` | `begin_checkout` (purchase_click удалён) | `SearchResults.tsx` / `ContactsAndPaymentStep.tsx` |
+| Клик «Purchase» → LiqPay | `add_payment_info` | `add_payment_info` (без изменений) | `SearchResults.tsx` |
+| Оплата подтверждена | `purchase` | `purchase` (фикс value + дедуп) | `return/page.tsx` |
+| Клик «Book» (бронь без оплаты) | `booking_success` | `reservation` (взвешенный value) | `SearchResults.tsx` |
+| Звонок / мессенджер / email | `phone_click` / `messenger_click` / `email_click` | `contact` (method + source) | `Header`, `AboutSection`, `SiteFooter`, `PurchaseClient`, `ParcelSection`→`Header` |
+| Долистал до секции | — | `view_section` (новое, Фаза 3) | `Schedule`/`About`/`ParcelSection`/`Routes` |
+| Указал направление без поиска | — | `search_intent` (новое, Фаза 3) | `SearchForm.tsx` |
+
+**Удалено:** `form_submit`, `purchase_click`.
+**Переименовано:** `view_item` → `add_to_cart`, `booking_success` → `reservation`,
+`phone_click`/`messenger_click`/`email_click` → `contact`.
+**Без изменений (раздел B):** `checkout_abandoned`, `payment_window_closed`,
+`download_ticket`, `fiscal_receipt_download_click`, `cancel_request`,
+`refund_request_submitted`.
+
+---
+
+## Полная карта событий (по точкам кода)
+
+### A. Воронка покупки (GA4 ecommerce)
+
+| # | Событие | Хелпер | Триггер |
+| --- | --- | --- | --- |
+| 1 | `search` | `trackSearch` | `SearchForm.handleSubmit` (валидная форма) |
+| 2 | `view_item_list` | `trackViewItemList` | `SearchResults` — useEffect после загрузки туров, один раз на запрос |
+| 3 | `select_item` | `trackSelectItem` | клик по рейсу (`onSelectOutbound` / `onSelectReturn`) |
+| 4 | `add_to_cart` | `trackAddToCart` | все места выбраны (`seatsDone`), один раз на выбор рейса |
+| 5 | `begin_checkout` | `trackBeginCheckout` | попадание на экран `ContactsAndPaymentStep` (`activeStep===3 && step2Complete`), **один раз, до развилки** |
+| 6 | `add_payment_info` | `trackAddPaymentInfo` | `handleAction("purchase")` и `handlePay` перед редиректом на LiqPay |
+| 7 | `purchase` | `trackPurchase` | `return/page.tsx` `firePurchaseEvent` при статусе paid |
+| 8 | `reservation` | `trackReservation` | `handleAction` только на ветке `action === "book"` |
+
+### Разница кнопок и защита от задвоения reservation/purchase
+
+- `handleAction("book")` — бронь **без** оплаты → шлём `reservation` (взвешенный value).
+- `handleAction("purchase")` — бронь + редирект на LiqPay → шлём `add_payment_info`,
+  затем `purchase` на `/return`.
+- `begin_checkout` шлётся **один раз** при попадании на экран оформления, **до**
+  развилки book/purchase (перенесён из клика в `useEffect`).
+- `reservation` физически недостижим на purchase-ветке: вызов стоит внутри
+  `if (action === "book")`. Если пользователь после брони нажмёт «Pay» и оплатит
+  онлайн — сработает `purchase`, а `reservation` повторно **не** шлётся (дедуп по
+  `purchaseId` + вес усредняет ценность и не задваивает выручку).
+
+### B. События без изменений
+
+`checkout_abandoned`, `payment_window_closed` (`return/page.tsx`),
+`download_ticket` (`ticketPdf.ts`), `fiscal_receipt_download_click`
+(`return/page.tsx`), `cancel_request`, `refund_request_submitted`
+(`PurchaseClient.tsx`).
+
+### C. Контакты — `contact` (`trackContact`)
+
+| Точка | method | source |
+| --- | --- | --- |
+| Хедер, звонок | `phone` | `topbar` |
+| Хедер, мессенджер | `telegram`/`viber`/`whatsapp` | `topbar` |
+| «О нас», звонок/мессенджер | `phone`/… | `about_section` |
+| Секция «Посылка» (открывает модал хедера) | по выбору | `parcel_section` |
+| Футер, звонок | `phone` | `footer` |
+| Футер, email | `email` | `footer` |
+| Деталь покупки | `phone`/`email` | `purchase_detail` |
+
+`source: "parcel_section"` — ключевой лид по посылкам: модал контактов один и тот же
+(в `Header.tsx`), но `source` определяется по точке открытия (топбар vs событие
+`open-contact-modal` из `ParcelSection`).
+
+### D. `view_section` (Фаза 3, `trackViewSection` + `useSectionView`)
+
+`section`: `prices` (`Schedule`), `about` (`About`), `parcel` (`ParcelSection`),
+`marshrut` (`Routes`). IntersectionObserver, порог ~50% (учитывается и покрытие
+вьюпорта для высоких секций). Дедуп: один раз за сессию на секцию (sessionStorage).
+
+> Значение `schedule` оставлено в типе, но на главной нет отдельной секции
+> расписания/таймтейбла — времена отправления живут внутри `marshrut` (Routes).
+
+### E. `search_intent` (Фаза 3, `trackSearchIntent`)
+
+Триггер: заполнены `departure` и `arrival`, но клика «Поиск» не было. Один раз за
+сессию, с задержкой 12с (не на каждый клик по дропдауну). Параметры: `departure`,
+`arrival`, `reached_date_step` (выбрана ли дата отправления). Завершённый `search`
+гасит `search_intent`.
+
+---
+
+## Критические правки purchase (Фаза 1)
+
+### 1. Источник `purchase.value` (баг ~72 373)
+
+`value` теперь считается как **сумма per-ticket fare**: `Σ ticket.pricing.price`
+(каждый билет = 1 место, `quantity: 1`). Это та же цена билета в основных единицах
+валюты, которую `PurchaseClient` рендерит через `formatCurrency` и суммирует как
+`ticketsSubtotal` — то есть «реальная цена билета текущей транзакции × количество».
+
+`trackPurchase` **всегда предпочитает** сумму по `items` и берёт `valueOverride`
+только когда у билетов нет цены. Резерв переупорядочен:
+
+1. `Σ ticket.pricing.price` (per-ticket fare) — основной источник;
+2. `ga_checkout_value` — сумма квоты, сохранённая в `sessionStorage` на шаге
+   `add_payment_info` (funnel-consistent, совпадает с суммой, которую видел
+   пользователь);
+3. `totals.paid` → `amount_due` — **именно этот резерв раньше улетал в ~72 373**;
+   теперь он используется в последнюю очередь.
+
+В dev-режиме `trackPurchase` логирует `valueSource` (`items` / `override`), чтобы в
+DebugView было видно, откуда взялось значение. Если `~72 373` появится снова —
+это значит, что `/public/purchase/{id}` на `/return` не отдал per-ticket `pricing`,
+и надо чинить include на бэкенде (фронт при этом уже подставит funnel-сумму из
+пункта 2, а не аномалию из пункта 3).
+
+### 2. Дедуп `purchase` по `transaction_id`
+
+Защита от повторной отправки при рефреше `/return`: отправленные `transaction_id`
+хранятся в `sessionStorage` + `localStorage` (`ga_purchase_fired_<id>`). Повторный
+вызов с тем же id — no-op.
+
+### 3. Валюта по локали
+
+`currency = purchaseView.purchase.currency ?? getCurrencyForLocale(lang)`.
+
+### Вес `reservation`
+
+`reservation.value = (цена билета × количество) × RESERVATION_WEIGHT`.
+`RESERVATION_WEIGHT` — именованная константа в `analytics.ts` (дефолт **0.5**),
+меняется в одном месте. Смысл: доля book-броней, доезжающих и оплачивающих не
+онлайн; усредняет ожидаемую ценность и не задваивает выручку с `purchase`.
+В событие также кладутся `reservation_value_full` (полная стоимость) и
+`reservation_weight` — для прозрачности.
+
+---
+
+## Отчёт: GTM и потенциальные проблемы
+
+- **Параллельного GTM-контейнера НЕ найдено.** В `src/app/layout.tsx` грузится
+  только GA4 `gtag` (`googletagmanager.com/gtag/js?id=G-...` + `gtag('config', …)`).
+  `GTM-XXXX` / `gtm.js` в проекте нет. Риска двойного счёта через GTM нет. GTM не
+  добавлялся.
+- **`fiscal_receipt_download_click`** (`return/page.tsx`) отправляется через
+  `window.dataLayer.push({ event: … })` (GTM-стиль), а не через `gtag('event', …)`.
+  Без GTM-контейнера такой push, скорее всего, **не доходит до GA4**. Оставлено без
+  изменений (раздел B — «не трогать»), но помечаю как потенциальную проблему: при
+  необходимости переведу на `trackEvent("fiscal_receipt_download_click", …)`
+  (тогда событие пойдёт через gtag + UTM). Требуется решение Димы.
+
+---
+
+## Чек-лист ручной верификации (GA4 DebugView)
+
+Открывать сайт с `?debug_mode=1` или включённым GA Debug (в dev `debug_mode: true`
+уже включён). В dev каждое событие также логируется в консоль как `[Analytics] …`.
+
+### 1. Полная воронка до онлайн-оплаты
+
+1. Открыть главную с UTM, напр. `/?utm_source=test&utm_medium=qa`.
+2. Выбрать departure + arrival + дату, нажать **«Поиск»**.
+   → `search` (origin/destination/route, `currency`, UTM-параметры `source/medium`).
+   → `form_submit` **не** должен появляться.
+3. На странице результатов после загрузки списка → `view_item_list`
+   (`items[]` рейсов, `item_count`).
+4. Кликнуть рейс → `select_item` (`items[0]` с price, `value`, `currency`).
+5. Выбрать места на всех пассажиров → `add_to_cart` (`items` с `quantity`,
+   `value`, `seats_outbound`).
+6. Заполнить контакты, попасть на экран оформления → `begin_checkout` **один раз**
+   (без `checkout_type`).
+7. Нажать **«Purchase»** → `add_payment_info` (`transaction_id`, `value`,
+   `payment_type: liqpay`), затем редирект на LiqPay.
+8. Оплатить → возврат на `/return` → `purchase` с корректными
+   `value` (реальная цена билета × кол-во, **не ~72 373**), `currency` (UAH для
+   ru/ua, EUR для en/bg), уникальным `transaction_id`, `items[]`.
+9. Обновить `/return` (F5) → `purchase` **повторно не** отправляется (дедуп).
+10. Проверить, что у всех событий шага 2–8 присутствуют UTM (`source`, `medium`).
+
+### 2. Бронь через «Book» (без оплаты)
+
+1. Пройти до экрана оформления, нажать **«Book»**.
+   → `begin_checkout` (один раз, при попадании на экран).
+   → после успешной брони — `reservation` **один раз** с взвешенным `value`
+   (полная сумма × 0.5), `reservation_value_full`, `reservation_weight: 0.5`.
+2. Повторный «Book» того же `purchaseId` — `reservation` не задваивается.
+
+### 3. `reservation` не шлётся на purchase-ветке
+
+1. Пройти путь **«Purchase»** (сразу оплата) до `/return`.
+   → есть `add_payment_info` и `purchase`, **нет** `reservation`.
+2. Сценарий book → затем «Pay» → оплата онлайн:
+   → `reservation` уже сработал на «Book»; на онлайн-оплате идёт `purchase`,
+   `reservation` **повторно не** шлётся.
+
+### 4. Контакты
+
+Кликнуть контакты в разных точках и проверить `contact` с верными `method`/`source`:
+
+- Хедер (звонок/мессенджер) → `source: topbar`, `method: phone|telegram|viber|whatsapp`.
+- «О нас» → `source: about_section`.
+- Кнопка в секции «Посылка» → открывается модал хедера → `source: parcel_section`.
+- Футер → `source: footer`, `method: phone|email`.
+- Страница покупки → `source: purchase_detail`, `method: phone|email`.
+
+### 5. Фаза 3
+
+- Долистать до секций → `view_section` по одному разу на секцию
+  (`prices`, `about`, `parcel`, `marshrut`); повторный скролл событие не задваивает.
+- Указать departure + arrival, **не** нажимать «Поиск», подождать ~12с →
+  `search_intent` (`departure`, `arrival`, `reached_date_step`). Если затем выбрать
+  дату но не искать — `reached_date_step: true`. Один раз за сессию.
+- Если нажать «Поиск» — идёт `search`, `search_intent` не появляется.

--- a/src/app/[locale]/(site)/return/page.tsx
+++ b/src/app/[locale]/(site)/return/page.tsx
@@ -15,7 +15,7 @@ import {
   trackPurchase,
   buildRouteCategory,
   daysUntil,
-  FALLBACK_CURRENCY,
+  getCurrencyForLocale,
 } from "@/lib/analytics";
 import { returnTranslations, dateLocaleMap } from "@/translations/return";
 import type { Lang } from "@/components/common/LanguageProvider";
@@ -731,6 +731,11 @@ function ReturnPageContent() {
       new Map(tickets.map((ticket) => [String(ticket.id), ticket])).values(),
     );
 
+    // Источник цены purchase.value (per-ticket fare): ticket.pricing.price —
+    // та же цена билета в основных единицах валюты, которую PurchaseClient
+    // рендерит через formatCurrency и суммирует как ticketsSubtotal. Каждый
+    // билет = 1 место (quantity: 1), поэтому value = Σ(цена билета × 1) =
+    // «реальная цена билета текущей транзакции × количество».
     const items = uniqueTickets.map((ticket) => {
       const direction = directionByTicketId.get(String(ticket.id));
       const departureName = ticket.segment_details?.departure?.name ?? "";
@@ -749,12 +754,32 @@ function ReturnPageContent() {
       };
     });
 
+    // Резерв для value, когда бэкенд не отдал per-ticket pricing. Порядок:
+    //  1) ga_checkout_value — сумма квоты, сохранённая на add_payment_info
+    //     (funnel-consistent, совпадает с суммой, которую видел пользователь);
+    //  2) totals.paid / amount_due — раньше именно этот резерв улетал в ~72 373.
+    // trackPurchase всегда предпочитает сумму по items (per-ticket fare) и
+    // берёт valueOverride ТОЛЬКО если у билетов нет цены.
+    let checkoutValueFallback: number | null = null;
+    try {
+      const stored = sessionStorage.getItem("ga_checkout_value");
+      if (stored) {
+        const parsed = Number(stored);
+        if (Number.isFinite(parsed) && parsed > 0) checkoutValueFallback = parsed;
+      }
+    } catch {
+      /* ignore */
+    }
+
     const fired = trackPurchase({
       transactionId,
       items,
-      currency: purchaseView.purchase.currency ?? FALLBACK_CURRENCY,
+      locale: lang,
+      currency: purchaseView.purchase.currency ?? getCurrencyForLocale(lang),
       valueOverride:
-        purchaseView.totals?.paid ?? purchaseView.purchase.amount_due,
+        checkoutValueFallback ??
+        purchaseView.totals?.paid ??
+        purchaseView.purchase.amount_due,
       extra: {
         passenger_count: uniqueTickets.length,
         trip_type: isRoundtrip ? "roundtrip" : "oneway",
@@ -767,6 +792,7 @@ function ReturnPageContent() {
       try {
         sessionStorage.removeItem("ga_checkout_start_ts");
         sessionStorage.removeItem("ga_checkout_purchase_id");
+        sessionStorage.removeItem("ga_checkout_value");
       } catch {
         /* ignore */
       }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -3,12 +3,14 @@
 
 import AboutSection from "@/components/about/AboutSection";
 import { useLanguage } from "@/components/common/LanguageProvider";
+import { useSectionView } from "@/utils/useSectionView";
 
 export default function About() {
   const { lang } = useLanguage();
+  const sectionRef = useSectionView<HTMLDivElement>("about");
 
   return (
-    <div id="about">
+    <div id="about" ref={sectionRef}>
       <AboutSection lang={lang} />
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useLanguage, type Lang } from "@/components/common/LanguageProvider";
+import { trackContact } from "@/lib/analytics";
 
 type MenuLabel = Record<Lang, string>;
 
@@ -114,6 +115,9 @@ export default function Header() {
   const { lang: current, setLang } = useLanguage();
   const [isContactOpen, setIsContactOpen] = useState(false);
   const [method, setMethod] = useState<"telegram" | "viber" | "whatsapp" | "call">("telegram");
+  // Один и тот же модал контактов открывается из топбара и из секции «Посылка»
+  // (событие open-contact-modal). source определяем по точке открытия.
+  const [contactSource, setContactSource] = useState<"topbar" | "parcel_section">("topbar");
   const t = contactTranslations[current];
 
   const handleChange = (v: Lang) => {
@@ -121,7 +125,10 @@ export default function Header() {
   };
 
   useEffect(() => {
-    const handler = () => setIsContactOpen(true);
+    const handler = () => {
+      setContactSource("parcel_section");
+      setIsContactOpen(true);
+    };
     window.addEventListener("open-contact-modal", handler);
 
     return () => window.removeEventListener("open-contact-modal", handler);
@@ -145,11 +152,11 @@ export default function Header() {
   };
 
   const trackContactClick = (phone: string) => {
-    if (method === "call") {
-      window.gtag?.("event", "phone_click", { event_category: "conversion", event_label: phone });
-      return;
-    }
-    window.gtag?.("event", "messenger_click", { event_category: "conversion", event_label: method });
+    trackContact({
+      method: method === "call" ? "phone" : method,
+      source: contactSource,
+      label: method === "call" ? phone : method,
+    });
   };
 
   return (
@@ -186,7 +193,10 @@ export default function Header() {
                 <li key="contacts">
                   <button
                     type="button"
-                    onClick={() => setIsContactOpen(true)}
+                    onClick={() => {
+                      setContactSource("topbar");
+                      setIsContactOpen(true);
+                    }}
                     className="inline-flex h-11 w-11 items-center justify-center rounded-[14px] border border-slate-200 bg-white text-slate-700 transition hover:-translate-y-0.5 hover:shadow-lg"
                     aria-label={item.label[current]}
                     title={item.label[current]}

--- a/src/components/ParcelSection.tsx
+++ b/src/components/ParcelSection.tsx
@@ -9,17 +9,19 @@ import {
   sectionEyebrowClass,
   sectionTitleClass,
 } from "@/components/common/designGuide";
+import { useSectionView } from "@/utils/useSectionView";
 
 export default function ParcelSection() {
   const { lang } = useLanguage();
   const t = parcelTranslations[lang];
+  const sectionRef = useSectionView<HTMLElement>("parcel");
 
   const handleClick = () => {
     window.dispatchEvent(new Event("open-contact-modal"));
   };
 
   return (
-    <section id="parcel" className={`${sectionBgMuted} py-16`}>
+    <section id="parcel" ref={sectionRef} className={`${sectionBgMuted} py-16`}>
       <div className="mx-auto w-full max-w-6xl px-4">
         <div className="text-center">
           <p className={sectionEyebrowClass}>{t.kicker}</p>

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -8,6 +8,7 @@ import { useLanguage, type Lang } from "@/components/common/LanguageProvider";
 import { routesTranslations } from "@/translations/home";
 import styles from "./Routes.module.css";
 import { sectionEyebrowClass, sectionTitleClass } from "./common/designGuide";
+import { useSectionView } from "@/utils/useSectionView";
 
 /* ===================== Types ===================== */
 
@@ -76,6 +77,7 @@ export default function Routes({ lang: langProp, hubLinks }: RoutesProps = {}) {
   const { lang: ctxLang } = useLanguage();
   const lang = langProp ?? ctxLang;
   const L = routesTranslations[lang];
+  const sectionRef = useSectionView<HTMLElement>("marshrut");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -114,7 +116,7 @@ export default function Routes({ lang: langProp, hubLinks }: RoutesProps = {}) {
   const hasAny = !!forward || !!backward;
 
   return (
-    <section id="routes" className={styles.routes}>
+    <section id="routes" ref={sectionRef} className={styles.routes}>
       <div className={styles.routesInner}>
         <header className={styles.routesHeader}>
           <p className={sectionEyebrowClass}>{L.eyebrow}</p>

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -10,6 +10,7 @@ import {
   sectionBgMuted,
 } from './common/designGuide';
 import type { Lang } from './common/LanguageProvider';
+import { useSectionView } from '@/utils/useSectionView';
 
 type PriceItem = {
   departure_stop_id: number;
@@ -29,6 +30,7 @@ export default function PriceListCompact({ lang = 'ru' }: { lang?: Lang }) {
   const [list, setList] = useState<PriceItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState(false);
+  const sectionRef = useSectionView<HTMLElement>('prices');
 
   useEffect(() => {
     let cancelled = false;
@@ -49,7 +51,7 @@ export default function PriceListCompact({ lang = 'ru' }: { lang?: Lang }) {
   }, [lang]);
 
   return (
-    <section id="prices" className={`${sectionBgMuted} py-16`}>
+    <section id="prices" ref={sectionRef} className={`${sectionBgMuted} py-16`}>
       <div className="mx-auto w-full max-w-6xl px-4">
         <div className="mb-10 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 
 import { useLanguage } from "@/components/common/LanguageProvider";
 import { getPublicOfferUrl } from "@/utils/publicOffer";
+import { trackContact } from "@/lib/analytics";
 
 // src/components/SiteFooter.tsx
 const translations = {
@@ -52,11 +53,11 @@ export default function SiteFooter() {
     : "";
 
   const trackPhoneClick = (phone: string) => {
-    window.gtag?.("event", "phone_click", { event_category: "conversion", event_label: phone });
+    trackContact({ method: "phone", source: "footer", label: phone });
   };
 
   const trackEmailClick = (email: string) => {
-    window.gtag?.("event", "email_click", { event_category: "conversion", event_label: email });
+    trackContact({ method: "email", source: "footer", label: email });
   };
 
   return (

--- a/src/components/about/AboutSection.tsx
+++ b/src/components/about/AboutSection.tsx
@@ -9,6 +9,7 @@ import {
 } from "../common/designGuide";
 import { aboutContent, type Lang } from "./content";
 import { aboutTranslations } from "@/translations/home";
+import { trackContact } from "@/lib/analytics";
 
 type Props = {
   lang?: Lang;
@@ -41,10 +42,10 @@ export default function AboutSection({
     `viber://chat?number=%2B${formatPhoneDigits(phone)}`;
   const buildTelegramLink = (phone: string) => `https://t.me/+${formatPhoneDigits(phone)}`;
   const trackPhoneClick = (phone: string) => {
-    window.gtag?.("event", "phone_click", { event_category: "conversion", event_label: phone });
+    trackContact({ method: "phone", source: "about_section", label: phone });
   };
   const trackMessengerClick = (messenger: "whatsapp" | "viber" | "telegram") => {
-    window.gtag?.("event", "messenger_click", { event_category: "conversion", event_label: messenger });
+    trackContact({ method: messenger, source: "about_section", label: messenger });
   };
 
   useEffect(() => {

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -9,7 +9,7 @@ import StopCombobox, { type StopComboboxHandle } from './StopCombobox';
 import apiClient from '@/lib/apiClient';
 import { useLockBodyScroll } from '@/utils/useLockBodyScroll';
 import { useModalVisibility } from '@/utils/useModalVisibility';
-import { trackEvent, buildRouteCategory } from '@/lib/analytics';
+import { trackSearch, buildRouteCategory } from '@/lib/analytics';
 
 type Stop = { id: number; stop_name: string };
 
@@ -224,29 +224,26 @@ export default function SearchForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    window.gtag?.("event", "form_submit", {
-      event_category: "conversion",
-      event_label: window.location.pathname,
-    });
     if (!fromId || !toId || !departDate) return;
     const fromName =
       departureStops.find((s) => s.id === fromId)?.stop_name || '';
     const toName =
       arrivalStops.find((s) => s.id === toId)?.stop_name || '';
-    trackEvent('search', {
-      search_term: `${fromName} → ${toName}`,
+    // Завершённое действие поиска. form_submit удалён как дубль без нагрузки.
+    trackSearch({
+      locale: lang,
       origin: fromName,
       destination: toName,
       route: buildRouteCategory(
         { id: fromId, name: fromName },
         { id: toId, name: toName },
       ),
-      departure_date: departDate,
-      return_date: returnDate || undefined,
-      trip_type: openReturn ? 'open_return' : returnDate ? 'roundtrip' : 'oneway',
-      passenger_count: passengers.adults + passengers.discount,
-      adult_count: passengers.adults,
-      discount_count: passengers.discount,
+      departureDate: departDate,
+      returnDate: returnDate || undefined,
+      tripType: openReturn ? 'open_return' : returnDate ? 'roundtrip' : 'oneway',
+      passengerCount: passengers.adults + passengers.discount,
+      adultCount: passengers.adults,
+      discountCount: passengers.discount,
     });
     onSearch({
       from: String(fromId),

--- a/src/components/hero/SearchForm.tsx
+++ b/src/components/hero/SearchForm.tsx
@@ -9,7 +9,7 @@ import StopCombobox, { type StopComboboxHandle } from './StopCombobox';
 import apiClient from '@/lib/apiClient';
 import { useLockBodyScroll } from '@/utils/useLockBodyScroll';
 import { useModalVisibility } from '@/utils/useModalVisibility';
-import { trackSearch, buildRouteCategory } from '@/lib/analytics';
+import { trackSearch, trackSearchIntent, buildRouteCategory } from '@/lib/analytics';
 
 type Stop = { id: number; stop_name: string };
 
@@ -205,6 +205,40 @@ export default function SearchForm({
     };
   }, [fromId, toId, seatCount]);
 
+  // ─── search_intent (намерение без результата, Фаза 3) ───────────────────
+  // Оба направления выбраны, но клик «Поиск» не сделан → шлём один раз за
+  // сессию, с задержкой (не на каждый клик/раскрытие дропдауна). Микро-действия
+  // (открытие departure/arrival/date) не трекаем.
+  const searchIntentSentRef = useRef(false);
+  const searchIntentNamesRef = useRef({ fromName: '', toName: '' });
+
+  useEffect(() => {
+    const fromName =
+      departureStops.find((s) => s.id === fromId)?.stop_name || '';
+    const toName = arrivalStops.find((s) => s.id === toId)?.stop_name || '';
+    searchIntentNamesRef.current = { fromName, toName };
+  }, [fromId, toId, departureStops, arrivalStops]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (searchIntentSentRef.current) return;
+    if (!fromId || !toId) return;
+    const timer = window.setTimeout(() => {
+      if (searchIntentSentRef.current) return;
+      const { fromName, toName } = searchIntentNamesRef.current;
+      const sent = trackSearchIntent({
+        locale: lang,
+        departure: fromName || String(fromId),
+        arrival: toName || String(toId),
+        // reached_date_step: дошёл ли до выбора даты (выбрана дата отправления),
+        // чтобы различать «бросил на направлении» vs «даты не подошли».
+        reachedDateStep: Boolean(departDate),
+      });
+      if (sent) searchIntentSentRef.current = true;
+    }, 12000);
+    return () => window.clearTimeout(timer);
+  }, [fromId, toId, departDate, lang]);
+
   const handleSwap = () => {
     setFrom(to);
     setTo(from);
@@ -229,6 +263,8 @@ export default function SearchForm({
       departureStops.find((s) => s.id === fromId)?.stop_name || '';
     const toName =
       arrivalStops.find((s) => s.id === toId)?.stop_name || '';
+    // Завершённый поиск — это не «намерение без результата»: гасим search_intent.
+    searchIntentSentRef.current = true;
     // Завершённое действие поиска. form_submit удалён как дубль без нагрузки.
     trackSearch({
       locale: lang,

--- a/src/components/purchase/PurchaseClient.tsx
+++ b/src/components/purchase/PurchaseClient.tsx
@@ -10,7 +10,7 @@ import Calendar from "@/components/Calendar";
 import SeatClient, { type SeatSelectionDetail } from "@/components/SeatClient";
 import { API } from "@/config";
 import { downloadTicketPdf } from "@/utils/ticketPdf";
-import { trackEvent, FALLBACK_CURRENCY } from "@/lib/analytics";
+import { trackEvent, trackContact, getCurrencyForLocale } from "@/lib/analytics";
 import { refundTranslations } from "@/translations/refund";
 import type {
   BaggageQuote,
@@ -1683,7 +1683,7 @@ export default function PurchaseClient({ purchaseId }: PurchaseClientProps) {
         currency:
           cancelPreview?.currency ||
           data.purchase.currency ||
-          FALLBACK_CURRENCY,
+          getCurrencyForLocale(lang),
         ticket_count: identifiers.length || cancelTickets.length,
       });
 
@@ -1707,6 +1707,7 @@ export default function PurchaseClient({ purchaseId }: PurchaseClientProps) {
     data,
     fetchPurchase,
     isActionDisabled,
+    lang,
     purchaseId,
     toOriginalTicketIds,
   ]);
@@ -2650,10 +2651,10 @@ export default function PurchaseClient({ purchaseId }: PurchaseClientProps) {
 
   const cancelButtonDisabled = isActionDisabled || cancelSelectionCount === 0;
   const trackPhoneClick = (phone: string) => {
-    window.gtag?.("event", "phone_click", { event_category: "conversion", event_label: phone });
+    trackContact({ method: "phone", source: "purchase_detail", label: phone });
   };
   const trackEmailClick = (email: string) => {
-    window.gtag?.("event", "email_click", { event_category: "conversion", event_label: email });
+    trackContact({ method: "email", source: "purchase_detail", label: email });
   };
 
 

--- a/src/components/search/BookingPanel.tsx
+++ b/src/components/search/BookingPanel.tsx
@@ -354,10 +354,7 @@ export default function BookingPanel({
 
       <form
         onSubmit={(e) => {
-          window.gtag?.("event", "form_submit", {
-            event_category: "conversion",
-            event_label: window.location.pathname,
-          });
+          // form_submit удалён как дубль search без полезной нагрузки.
           e.preventDefault();
         }}
         className="mt-2 flex w-full max-w-[640px] flex-col gap-3 rounded-none bg-transparent p-0 shadow-none ring-0 sm:rounded-xl sm:bg-white/70 sm:p-4 sm:shadow-sm sm:ring-1 sm:ring-slate-200"

--- a/src/components/search/ContactsAndPaymentStep.tsx
+++ b/src/components/search/ContactsAndPaymentStep.tsx
@@ -93,12 +93,8 @@ export default function ContactsAndPaymentStep({
   canPay,
   onDownloadTicket,
 }: Props) {
-  const trackPurchaseClick = () => {
-    window.gtag?.("event", "purchase_click", {
-      event_category: "conversion",
-      event_label: `${fromName} → ${toName}`.trim() || window.location.pathname,
-    });
-  };
+  // purchase_click удалён (дубль begin_checkout без полезной нагрузки).
+  // begin_checkout шлётся один раз при попадании на этот экран из SearchResults.
   const badgeTone = "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold";
 
   const setBaggageValue = (idx: number, direction: "outbound" | "return", value: boolean) => {
@@ -321,7 +317,6 @@ export default function ContactsAndPaymentStep({
         <button
           type="button"
           onClick={() => {
-            trackPurchaseClick();
             handleAction("book");
           }}
           className="rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-800 shadow-sm transition hover:-translate-y-px hover:border-slate-300 hover:shadow"
@@ -331,7 +326,6 @@ export default function ContactsAndPaymentStep({
         <button
           type="button"
           onClick={() => {
-            trackPurchaseClick();
             handleAction("purchase");
           }}
           className="rounded-full bg-emerald-600 px-6 py-3 text-sm font-semibold text-white shadow hover:bg-emerald-700"

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -17,10 +17,14 @@ import StepThree from "./steps/StepThree";
 
 import { downloadTicketPdf } from "@/utils/ticketPdf";
 import {
-  trackEvent,
-  trackBooking,
+  trackViewItemList,
+  trackSelectItem,
+  trackAddToCart,
+  trackBeginCheckout,
+  trackAddPaymentInfo,
+  trackReservation,
   buildRouteCategory,
-  FALLBACK_CURRENCY,
+  type EcommerceItem,
 } from "@/lib/analytics";
 import { getPublicOfferUrl } from "@/utils/publicOffer";
 import {
@@ -275,8 +279,9 @@ export default function SearchResults({
 
   // Выбор рейсов
   const onSelectOutbound = (tour: SearchTour) => {
-    trackEvent("select_item", {
-      item_list_name: "search_results_outbound",
+    trackSelectItem({
+      locale: lang,
+      listName: "search_results_outbound",
       items: [
         {
           item_id: String(tour.id),
@@ -288,9 +293,11 @@ export default function SearchResults({
           ),
           price: tour.price,
           item_variant: tour.date,
+          departure: fromName,
+          arrival: toName,
+          travel_date: tour.date,
         },
       ],
-      currency: FALLBACK_CURRENCY,
       value: tour.price,
     });
     setSelectedOutboundTour(tour);
@@ -300,8 +307,9 @@ export default function SearchResults({
   };
 
   const onSelectReturn = (tour: SearchTour) => {
-    trackEvent("select_item", {
-      item_list_name: "search_results_return",
+    trackSelectItem({
+      locale: lang,
+      listName: "search_results_return",
       items: [
         {
           item_id: String(tour.id),
@@ -313,9 +321,11 @@ export default function SearchResults({
           ),
           price: tour.price,
           item_variant: tour.date,
+          departure: toName,
+          arrival: fromName,
+          travel_date: tour.date,
         },
       ],
-      currency: FALLBACK_CURRENCY,
       value: tour.price,
     });
     setSelectedReturnTour(tour);
@@ -376,16 +386,9 @@ export default function SearchResults({
       setMsg(action === "purchase" ? "Покупка…" : "Бронирование…");
       setMsgType("info");
 
-      const checkoutItems = buildCheckoutItems();
-      trackEvent("begin_checkout", {
-        value: overallTotal,
-        currency: FALLBACK_CURRENCY,
-        items: checkoutItems.items,
-        passenger_count: safeSeatCount,
-        trip_type: checkoutItems.tripType,
-        route: checkoutItems.route,
-        checkout_type: action,
-      });
+      // begin_checkout больше НЕ шлётся здесь: он отправляется один раз при
+      // попадании на экран оформления (ContactsAndPaymentStep), до развилки
+      // book/purchase. purchase_click удалён.
 
       const isTwoStepPurchaseFallback =
         action === "purchase" && ENABLE_TWO_STEP_PURCHASE_FALLBACK;
@@ -551,12 +554,22 @@ export default function SearchResults({
       setMsgType("success");
 
       if (action === "book") {
-        trackBooking({
+        // reservation срабатывает ТОЛЬКО на пути «book» (бронь без онлайн-оплаты).
+        // На пути «purchase» этот блок недостижим, поэтому reservation не может
+        // выстрелить на purchase-ветке и не задваивается с purchase.
+        const reservationItems = buildCheckoutItems();
+        trackReservation({
           purchaseId: pId,
+          locale: lang,
+          items: reservationItems.items,
+          value: Number(total),
           tripFrom: fromName,
           tripTo: toName,
-          value: Number(total),
-          currency: FALLBACK_CURRENCY,
+          extra: {
+            passenger_count: safeSeatCount,
+            trip_type: reservationItems.tripType,
+            route: reservationItems.route,
+          },
         });
       }
 
@@ -576,17 +589,25 @@ export default function SearchResults({
 
         const checkoutPayload = normalizePublicPayResponse(finalPurchaseResponse);
         persistLastLiqPayOrderId(checkoutPayload.orderId);
-        trackEvent("add_payment_info", {
-          transaction_id: String(pId),
+        const paymentItems = buildCheckoutItems();
+        trackAddPaymentInfo({
+          locale: lang,
+          transactionId: String(pId),
+          items: paymentItems.items,
           value: Number(total),
-          currency: FALLBACK_CURRENCY,
-          payment_type: "liqpay",
-          passenger_count: safeSeatCount,
-          trip_type: tripTypeLabel,
+          paymentType: "liqpay",
+          extra: {
+            passenger_count: safeSeatCount,
+            trip_type: tripTypeLabel,
+            route: paymentItems.route,
+          },
         });
         if (typeof window !== "undefined") {
           sessionStorage.setItem("ga_checkout_start_ts", String(Date.now()));
           sessionStorage.setItem("ga_checkout_purchase_id", String(pId));
+          // Funnel-consistent резерв для purchase.value на /return, если бэкенд
+          // не вернёт per-ticket pricing (см. return/page.tsx).
+          sessionStorage.setItem("ga_checkout_value", String(Number(total)));
         }
         setMsg("Перенаправляем на страницу оплаты…");
         setMsgType("info");
@@ -632,17 +653,24 @@ export default function SearchResults({
 
       const checkoutPayload = normalizePublicPayResponse(response.data);
       persistLastLiqPayOrderId(checkoutPayload.orderId);
-      trackEvent("add_payment_info", {
-        transaction_id: String(purchaseId),
+      const paymentItems = buildCheckoutItems();
+      trackAddPaymentInfo({
+        locale: lang,
+        transactionId: String(purchaseId),
+        items: paymentItems.items,
         value: overallTotal,
-        currency: FALLBACK_CURRENCY,
-        payment_type: "liqpay",
-        passenger_count: safeSeatCount,
-        trip_type: tripTypeLabel,
+        paymentType: "liqpay",
+        extra: {
+          passenger_count: safeSeatCount,
+          trip_type: tripTypeLabel,
+          route: paymentItems.route,
+        },
       });
       if (typeof window !== "undefined") {
         sessionStorage.setItem("ga_checkout_start_ts", String(Date.now()));
         sessionStorage.setItem("ga_checkout_purchase_id", String(purchaseId));
+        // Funnel-consistent резерв для purchase.value на /return.
+        sessionStorage.setItem("ga_checkout_value", String(overallTotal));
       }
       submitLiqPayCheckout(
         checkoutPayload.checkoutFormUrl,
@@ -976,7 +1004,7 @@ export default function SearchResults({
       { id: fromId, name: fromName },
       { id: toId, name: toName },
     );
-    const items: Record<string, unknown>[] = [];
+    const items: EcommerceItem[] = [];
     if (selectedOutboundTour) {
       items.push({
         item_id: String(selectedOutboundTour.id),
@@ -1011,36 +1039,103 @@ export default function SearchResults({
     toName,
   ]);
 
-  const viewItemFiredRef = useRef(false);
+  // view_item_list: отрисован список рейсов (после загрузки туров). Один раз
+  // на поисковый запрос.
+  const viewItemListFiredRef = useRef(false);
   useEffect(() => {
-    if (activeStep !== 2) return;
-    if (!selectedOutboundTour) return;
-    if (returnDate && !openReturn && !selectedReturnTour) return;
-    if (viewItemFiredRef.current) return;
-    viewItemFiredRef.current = true;
-    const { items, tripType, route } = buildCheckoutItems();
-    trackEvent("view_item", {
-      items,
-      value: overallTotal,
-      currency: FALLBACK_CURRENCY,
-      trip_type: tripType,
-      route,
-      passenger_count: safeSeatCount,
-    });
-  }, [
-    activeStep,
-    buildCheckoutItems,
-    openReturn,
-    overallTotal,
-    returnDate,
-    safeSeatCount,
-    selectedOutboundTour,
-    selectedReturnTour,
-  ]);
+    viewItemListFiredRef.current = false;
+  }, [fromId, toId, date, returnDate, safeSeatCount]);
 
   useEffect(() => {
-    if (!selectedOutboundTour) viewItemFiredRef.current = false;
-  }, [selectedOutboundTour]);
+    if (loading) return;
+    if (!outboundTours.length) return;
+    if (viewItemListFiredRef.current) return;
+    viewItemListFiredRef.current = true;
+    const route = buildRouteCategory(
+      { id: fromId, name: fromName },
+      { id: toId, name: toName },
+    );
+    trackViewItemList({
+      locale: lang,
+      listId: "search_results_outbound",
+      listName: "search_results_outbound",
+      items: outboundTours.map((tour) => ({
+        item_id: String(tour.id),
+        item_name: `${fromName} → ${toName}`,
+        item_category: returnDate ? "roundtrip" : "oneway",
+        item_category2: route,
+        item_variant: tour.date,
+        price: tour.price,
+      })),
+      extra: { item_count: outboundTours.length, route },
+    });
+  }, [loading, outboundTours, fromName, toName, returnDate, fromId, toId, lang]);
+
+  // add_to_cart: рейс + место зафиксированы (бывший view_item). Один раз на
+  // текущий выбор рейсов; сбрасывается при смене рейса.
+  const addToCartFiredRef = useRef(false);
+  const beginCheckoutFiredRef = useRef(false);
+  useEffect(() => {
+    addToCartFiredRef.current = false;
+    beginCheckoutFiredRef.current = false;
+  }, [selectedOutboundTour?.id, selectedReturnTour?.id]);
+
+  useEffect(() => {
+    if (!selectedOutboundTour) return;
+    if (returnRequired && !selectedReturnTour) return;
+    if (!seatsDone) return;
+    if (addToCartFiredRef.current) return;
+    addToCartFiredRef.current = true;
+    const { items, tripType, route } = buildCheckoutItems();
+    trackAddToCart({
+      locale: lang,
+      items,
+      value: overallTotal,
+      extra: {
+        trip_type: tripType,
+        route,
+        passenger_count: safeSeatCount,
+        seats_outbound: [...selectedOutboundSeats],
+        ...(selectedReturnTour ? { seats_return: [...selectedReturnSeats] } : {}),
+      },
+    });
+  }, [
+    seatsDone,
+    returnRequired,
+    selectedOutboundTour,
+    selectedReturnTour,
+    selectedOutboundSeats,
+    selectedReturnSeats,
+    buildCheckoutItems,
+    overallTotal,
+    safeSeatCount,
+    lang,
+  ]);
+
+  // begin_checkout: попадание на экран оформления (ContactsAndPaymentStep),
+  // ОДИН раз, до развилки book/purchase.
+  useEffect(() => {
+    if (ticket) return;
+    if (activeStep !== 3) return;
+    if (!step2Complete) return;
+    if (beginCheckoutFiredRef.current) return;
+    beginCheckoutFiredRef.current = true;
+    const { items, tripType, route } = buildCheckoutItems();
+    trackBeginCheckout({
+      locale: lang,
+      items,
+      value: overallTotal,
+      extra: { trip_type: tripType, route, passenger_count: safeSeatCount },
+    });
+  }, [
+    ticket,
+    activeStep,
+    step2Complete,
+    buildCheckoutItems,
+    overallTotal,
+    safeSeatCount,
+    lang,
+  ]);
 
   const baggagePriceLabels = useMemo(
     () => ({

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -4,7 +4,12 @@ import * as assert from "node:assert/strict";
 import {
   toFiniteNumber,
   trackPurchase,
-  FALLBACK_CURRENCY,
+  trackReservation,
+  getCurrencyForLocale,
+  trackContact,
+  trackViewSection,
+  trackSearchIntent,
+  RESERVATION_WEIGHT,
 } from "./analytics";
 
 type GtagCall = { event: string; params: Record<string, unknown> };
@@ -196,13 +201,23 @@ test("trackPurchase prevents duplicate events with same transactionId", () => {
   assert.equal(ctx.calls.length, 1);
 });
 
-test("trackPurchase applies fallback currency when not provided", () => {
+test("trackPurchase defaults currency to UAH when locale is not provided", () => {
   trackPurchase({
     transactionId: "tx-cur",
     items: [{ item_id: "a", price: 2600 }],
   });
 
-  assert.equal(ctx.calls[0]?.params.currency, FALLBACK_CURRENCY);
+  assert.equal(ctx.calls[0]?.params.currency, "UAH");
+});
+
+test("trackPurchase derives currency from locale (EUR for en/bg)", () => {
+  trackPurchase({
+    transactionId: "tx-cur-en",
+    items: [{ item_id: "a", price: 2600 }],
+    locale: "en",
+  });
+
+  assert.equal(ctx.calls[0]?.params.currency, "EUR");
 });
 
 test("trackPurchase normalizes invalid quantity to 1", () => {
@@ -235,4 +250,129 @@ test("trackPurchase rounds value to 2 decimals", () => {
 
   const value = ctx.calls[0]?.params.value as number;
   assert.equal(value, 301.71);
+});
+
+// ─────────────────────── getCurrencyForLocale ───────────────────────────
+
+test("getCurrencyForLocale maps ru/ua to UAH and en/bg to EUR", () => {
+  assert.equal(getCurrencyForLocale("ru"), "UAH");
+  assert.equal(getCurrencyForLocale("ua"), "UAH");
+  assert.equal(getCurrencyForLocale("en"), "EUR");
+  assert.equal(getCurrencyForLocale("bg"), "EUR");
+});
+
+test("getCurrencyForLocale accepts Intl locale strings", () => {
+  assert.equal(getCurrencyForLocale("ru-RU"), "UAH");
+  assert.equal(getCurrencyForLocale("uk-UA"), "UAH");
+  assert.equal(getCurrencyForLocale("en-US"), "EUR");
+  assert.equal(getCurrencyForLocale("bg-BG"), "EUR");
+});
+
+test("getCurrencyForLocale defaults to UAH for unknown/empty locale", () => {
+  assert.equal(getCurrencyForLocale(undefined), "UAH");
+  assert.equal(getCurrencyForLocale(null), "UAH");
+  assert.equal(getCurrencyForLocale(""), "UAH");
+  assert.equal(getCurrencyForLocale("zz"), "UAH");
+});
+
+// ───────────────────────── trackReservation ─────────────────────────────
+
+test("trackReservation applies RESERVATION_WEIGHT to value", () => {
+  const fired = trackReservation({
+    purchaseId: "res-1",
+    items: [{ item_id: "a", price: 2600, quantity: 1 }],
+  });
+
+  assert.equal(fired, true);
+  assert.equal(ctx.calls.length, 1);
+  const call = ctx.calls[0];
+  assert.equal(call.event, "reservation");
+  assert.equal(call.params.value, 2600 * RESERVATION_WEIGHT);
+  assert.equal(call.params.reservation_value_full, 2600);
+  assert.equal(call.params.reservation_weight, RESERVATION_WEIGHT);
+  assert.equal(call.params.transaction_id, "res-1");
+});
+
+test("trackReservation uses explicit value over items when provided", () => {
+  trackReservation({
+    purchaseId: "res-2",
+    value: 5000,
+    items: [{ item_id: "a", price: 2600, quantity: 1 }],
+    currency: "UAH",
+  });
+
+  assert.equal(ctx.calls[0]?.params.value, 5000 * RESERVATION_WEIGHT);
+});
+
+test("trackReservation derives currency from locale", () => {
+  trackReservation({
+    purchaseId: "res-cur",
+    value: 1000,
+    locale: "bg",
+  });
+
+  assert.equal(ctx.calls[0]?.params.currency, "EUR");
+});
+
+test("trackReservation prevents duplicate events with same purchaseId", () => {
+  const first = trackReservation({ purchaseId: "res-dup", value: 1000 });
+  const second = trackReservation({ purchaseId: "res-dup", value: 1000 });
+
+  assert.equal(first, true);
+  assert.equal(second, false);
+  assert.equal(ctx.calls.length, 1);
+});
+
+test("trackReservation skips when purchaseId is missing", () => {
+  const fired = trackReservation({ purchaseId: "", value: 1000 });
+  assert.equal(fired, false);
+  assert.equal(ctx.calls.length, 0);
+});
+
+// ─────────────────────────── trackContact ───────────────────────────────
+
+test("trackContact emits a single parameterized contact event", () => {
+  trackContact({ method: "phone", source: "footer", label: "+380930004636" });
+
+  assert.equal(ctx.calls.length, 1);
+  const call = ctx.calls[0];
+  assert.equal(call.event, "contact");
+  assert.equal(call.params.method, "phone");
+  assert.equal(call.params.source, "footer");
+  assert.equal(call.params.event_label, "+380930004636");
+});
+
+// ────────────────── trackViewSection / trackSearchIntent ─────────────────
+
+test("trackViewSection fires once per section per session", () => {
+  const first = trackViewSection("parcel");
+  const second = trackViewSection("parcel");
+  const other = trackViewSection("prices");
+
+  assert.equal(first, true);
+  assert.equal(second, false);
+  assert.equal(other, true);
+  assert.equal(ctx.calls.length, 2);
+  assert.equal(ctx.calls[0]?.event, "view_section");
+  assert.equal(ctx.calls[0]?.params.section, "parcel");
+});
+
+test("trackSearchIntent fires once per session with reached_date_step", () => {
+  const first = trackSearchIntent({
+    departure: "Odessa",
+    arrival: "Varna",
+    reachedDateStep: true,
+  });
+  const second = trackSearchIntent({
+    departure: "Odessa",
+    arrival: "Kyiv",
+    reachedDateStep: false,
+  });
+
+  assert.equal(first, true);
+  assert.equal(second, false);
+  assert.equal(ctx.calls.length, 1);
+  assert.equal(ctx.calls[0]?.event, "search_intent");
+  assert.equal(ctx.calls[0]?.params.departure, "Odessa");
+  assert.equal(ctx.calls[0]?.params.reached_date_step, true);
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -54,6 +54,13 @@ const getDeviceType = () => {
   return /mobile|android|iphone|ipad/i.test(navigator.userAgent) ? "mobile" : "desktop";
 };
 
+/**
+ * Единственная точка отправки событий в GA4. UTM-атрибуция и тип устройства
+ * прикрепляются здесь, поэтому ЛЮБОЕ событие, отправленное через trackEvent
+ * (напрямую или через типизированные хелперы ниже), автоматически обогащается
+ * UTM. Голых window.gtag() вызовов в компонентах быть не должно — иначе часть
+ * событий уйдёт без UTM.
+ */
 export const trackEvent = (eventName: string, params?: GtagParams) => {
   if (typeof window === "undefined") return;
   const w = window as unknown as { gtag?: (...args: unknown[]) => void };
@@ -84,7 +91,39 @@ export const setUserProperties = (props: GtagParams) => {
   }
 };
 
-export const FALLBACK_CURRENCY = "UAH";
+// ───────────────────────── Currency by locale ─────────────────────────────
+
+export type Locale = string | null | undefined;
+
+/**
+ * Валюта отчётности по локали:
+ *   ru / ua (uk) → "UAH"
+ *   en / bg      → "EUR"
+ * Принимает как коды приложения ("ru", "ua", "en", "bg"), так и Intl-локали
+ * ("ru-RU", "uk-UA", "en-US", "bg-BG"). Дефолт — UAH (основной рынок).
+ *
+ * Заменяет жёсткую константу FALLBACK_CURRENCY: валюта теперь всегда выводится
+ * из локали, а не хардкодится по месту.
+ */
+export const getCurrencyForLocale = (locale?: Locale): "UAH" | "EUR" => {
+  const base = String(locale ?? "")
+    .toLowerCase()
+    .split(/[-_]/)[0];
+  if (base === "en" || base === "bg") return "EUR";
+  // ru, ua, uk и всё остальное → UAH
+  return "UAH";
+};
+
+/**
+ * Доля «book»-броней (бронь без онлайн-оплаты), которые в итоге доезжают и
+ * оплачивают офлайн. Взвешивает ценность события reservation, чтобы не задваивать
+ * выручку с purchase и усреднить ожидаемую ценность по популяции.
+ *
+ * Настраивается Димой по данным бэкенда. Значение меняется здесь, в одном месте.
+ */
+export const RESERVATION_WEIGHT = 0.5;
+
+// ───────────────────────── Shared helpers ─────────────────────────────────
 
 export const buildRouteCategory = (
   from: { id?: string | number | null; name: string },
@@ -109,7 +148,7 @@ export const toFiniteNumber = (value: unknown): number | null => {
   if (typeof value === "string") {
     const trimmed = value.trim();
     if (!trimmed) return null;
-    const cleaned = trimmed.replace(/[\s ]/g, "");
+    const cleaned = trimmed.replace(/[\s ]/g, "");
     const lastComma = cleaned.lastIndexOf(",");
     const lastDot = cleaned.lastIndexOf(".");
     let normalized = cleaned;
@@ -127,7 +166,9 @@ export const toFiniteNumber = (value: unknown): number | null => {
   return Number.isFinite(numeric) ? numeric : null;
 };
 
-export type PurchaseEventItem = {
+// ───────────────────────── Ecommerce items ────────────────────────────────
+
+export type EcommerceItem = {
   item_id: string;
   item_name?: string;
   item_category?: string;
@@ -138,16 +179,46 @@ export type PurchaseEventItem = {
   [extra: string]: unknown;
 };
 
-export type TrackPurchaseParams = {
-  transactionId: string | number | null | undefined;
-  items: PurchaseEventItem[];
-  currency?: string | null;
-  valueOverride?: number | string | null;
-  extra?: GtagParams;
-};
+/** @deprecated Используйте EcommerceItem. Сохранён для обратной совместимости. */
+export type PurchaseEventItem = EcommerceItem;
 
-const PURCHASE_FIRED_KEY_PREFIX = "ga_purchase_fired_";
-const MAX_REASONABLE_PURCHASE_VALUE = 1_000_000;
+/**
+ * Приводит item к консистентному виду: item_id — строка, price — положительное
+ * число в основных единицах валюты (гривны/евро, не копейки/центы), quantity —
+ * положительное число (по умолчанию 1). Прочие поля (departure, arrival,
+ * travel_date, seat …) сохраняются как есть.
+ */
+const normalizeItems = (items: EcommerceItem[] | undefined): EcommerceItem[] =>
+  (Array.isArray(items) ? items : []).map((item) => {
+    const price = toFiniteNumber(item.price);
+    const quantity = toFiniteNumber(item.quantity);
+    const safePrice = price !== null && price > 0 ? Number(price.toFixed(2)) : 0;
+    const safeQty = quantity !== null && quantity > 0 ? quantity : 1;
+    return {
+      ...item,
+      item_id: String(item.item_id ?? ""),
+      price: safePrice,
+      quantity: safeQty,
+    };
+  });
+
+const sumItemsValue = (items: EcommerceItem[]): number =>
+  items.reduce(
+    (sum, item) => sum + (Number(item.price) || 0) * (Number(item.quantity) || 0),
+    0,
+  );
+
+const round2 = (value: number): number => Number((Number.isFinite(value) ? value : 0).toFixed(2));
+
+/** Значение события: явный override, иначе — сумма по items. */
+const resolveValue = (
+  items: EcommerceItem[],
+  valueOverride?: number | string | null,
+): number => {
+  const override = toFiniteNumber(valueOverride);
+  if (override !== null && override > 0) return round2(override);
+  return round2(sumItemsValue(items));
+};
 
 const isDev = () => process.env.NODE_ENV !== "production";
 
@@ -176,6 +247,157 @@ const safeStorageSet = (key: string, value: string) => {
   }
 };
 
+// ═══════════════════════ Purchase funnel (GA4 ecommerce) ═══════════════════
+//
+// Единая схема параметров: currency (по локали) + value (основные единицы) +
+// items[]. Порядок воронки:
+//   search → view_item_list → select_item → add_to_cart → begin_checkout
+//   → add_payment_info → purchase   (онлайн-оплата)
+//   … либо begin_checkout → reservation   (бронь без онлайн-оплаты)
+
+// ── 1. search ──────────────────────────────────────────────────────────────
+export type TrackSearchParams = {
+  locale?: Locale;
+  origin: string;
+  destination: string;
+  route?: string;
+  departureDate?: string;
+  returnDate?: string;
+  tripType?: string;
+  passengerCount?: number;
+  adultCount?: number;
+  discountCount?: number;
+  extra?: GtagParams;
+};
+
+export const trackSearch = (params: TrackSearchParams) => {
+  trackEvent("search", {
+    search_term: `${params.origin} → ${params.destination}`,
+    origin: params.origin,
+    destination: params.destination,
+    route: params.route,
+    departure_date: params.departureDate,
+    return_date: params.returnDate || undefined,
+    trip_type: params.tripType,
+    passenger_count: params.passengerCount,
+    adult_count: params.adultCount,
+    discount_count: params.discountCount,
+    currency: getCurrencyForLocale(params.locale),
+    ...(params.extra ?? {}),
+  });
+};
+
+// ── 2. view_item_list ────────────────────────────────────────────────────
+export type TrackViewItemListParams = {
+  locale?: Locale;
+  listId?: string;
+  listName?: string;
+  items: EcommerceItem[];
+  extra?: GtagParams;
+};
+
+export const trackViewItemList = (params: TrackViewItemListParams) => {
+  trackEvent("view_item_list", {
+    item_list_id: params.listId,
+    item_list_name: params.listName,
+    currency: getCurrencyForLocale(params.locale),
+    items: normalizeItems(params.items),
+    ...(params.extra ?? {}),
+  });
+};
+
+// ── 3. select_item ────────────────────────────────────────────────────────
+export type TrackSelectItemParams = {
+  locale?: Locale;
+  listName?: string;
+  items: EcommerceItem[];
+  value?: number | string | null;
+  extra?: GtagParams;
+};
+
+export const trackSelectItem = (params: TrackSelectItemParams) => {
+  const items = normalizeItems(params.items);
+  trackEvent("select_item", {
+    item_list_name: params.listName,
+    items,
+    currency: getCurrencyForLocale(params.locale),
+    value: resolveValue(items, params.value),
+    ...(params.extra ?? {}),
+  });
+};
+
+// ── 4. add_to_cart (фиксация рейс+место) ─────────────────────────────────
+export type TrackAddToCartParams = {
+  locale?: Locale;
+  items: EcommerceItem[];
+  value?: number | string | null;
+  extra?: GtagParams;
+};
+
+export const trackAddToCart = (params: TrackAddToCartParams) => {
+  const items = normalizeItems(params.items);
+  trackEvent("add_to_cart", {
+    items,
+    currency: getCurrencyForLocale(params.locale),
+    value: resolveValue(items, params.value),
+    ...(params.extra ?? {}),
+  });
+};
+
+// ── 5. begin_checkout (попадание на экран оформления) ────────────────────
+export type TrackBeginCheckoutParams = {
+  locale?: Locale;
+  items: EcommerceItem[];
+  value?: number | string | null;
+  extra?: GtagParams;
+};
+
+export const trackBeginCheckout = (params: TrackBeginCheckoutParams) => {
+  const items = normalizeItems(params.items);
+  trackEvent("begin_checkout", {
+    items,
+    currency: getCurrencyForLocale(params.locale),
+    value: resolveValue(items, params.value),
+    ...(params.extra ?? {}),
+  });
+};
+
+// ── 6. add_payment_info (клик Purchase → редирект на LiqPay) ─────────────
+export type TrackAddPaymentInfoParams = {
+  locale?: Locale;
+  transactionId?: string | number | null;
+  items?: EcommerceItem[];
+  value?: number | string | null;
+  paymentType?: string;
+  extra?: GtagParams;
+};
+
+export const trackAddPaymentInfo = (params: TrackAddPaymentInfoParams) => {
+  const items = normalizeItems(params.items);
+  trackEvent("add_payment_info", {
+    transaction_id:
+      params.transactionId != null ? String(params.transactionId) : undefined,
+    ...(items.length ? { items } : {}),
+    currency: getCurrencyForLocale(params.locale),
+    value: resolveValue(items, params.value),
+    payment_type: params.paymentType ?? "liqpay",
+    ...(params.extra ?? {}),
+  });
+};
+
+// ── 7. purchase (оплата подтверждена) ────────────────────────────────────
+export type TrackPurchaseParams = {
+  transactionId: string | number | null | undefined;
+  items: EcommerceItem[];
+  locale?: Locale;
+  currency?: string | null;
+  valueOverride?: number | string | null;
+  extra?: GtagParams;
+};
+
+const PURCHASE_FIRED_KEY_PREFIX = "ga_purchase_fired_";
+const MAX_REASONABLE_PURCHASE_VALUE = 1_000_000;
+
 export const trackPurchase = (params: TrackPurchaseParams): boolean => {
   if (typeof window === "undefined") return false;
 
@@ -192,25 +414,13 @@ export const trackPurchase = (params: TrackPurchaseParams): boolean => {
     return false;
   }
 
-  const items = Array.isArray(params.items) ? params.items : [];
-  const normalizedItems = items.map((item) => {
-    const price = toFiniteNumber(item.price);
-    const quantity = toFiniteNumber(item.quantity);
-    const safePrice = price !== null && price > 0 ? Number(price.toFixed(2)) : 0;
-    const safeQty = quantity !== null && quantity > 0 ? quantity : 1;
-    return {
-      ...item,
-      item_id: String(item.item_id ?? ""),
-      price: safePrice,
-      quantity: safeQty,
-    };
-  });
+  const normalizedItems = normalizeItems(params.items);
 
-  const itemsValue = normalizedItems.reduce(
-    (sum, item) => sum + item.price * item.quantity,
-    0,
-  );
-
+  // Канонический источник value — сумма цен билетов текущей транзакции
+  // (ticket.price × quantity) в основных единицах валюты. valueOverride
+  // (например totals.paid / amount_due) используется ТОЛЬКО как резерв, когда
+  // у билетов нет цены: раньше именно этот резерв улетал в ~72 373.
+  const itemsValue = sumItemsValue(normalizedItems);
   const overrideValue = toFiniteNumber(params.valueOverride);
   const value =
     itemsValue > 0
@@ -218,6 +428,8 @@ export const trackPurchase = (params: TrackPurchaseParams): boolean => {
       : overrideValue !== null && overrideValue > 0
         ? overrideValue
         : 0;
+  const valueSource =
+    itemsValue > 0 ? "items" : overrideValue && overrideValue > 0 ? "override" : "none";
 
   if (!Number.isFinite(value) || value <= 0) {
     if (isDev()) {
@@ -268,11 +480,11 @@ export const trackPurchase = (params: TrackPurchaseParams): boolean => {
     return false;
   }
 
-  const roundedValue = Number(value.toFixed(2));
+  const roundedValue = round2(value);
   const payload: GtagParams = {
     transaction_id: transactionId,
     value: roundedValue,
-    currency: params.currency || FALLBACK_CURRENCY,
+    currency: params.currency || getCurrencyForLocale(params.locale),
     items: normalizedItems,
     ...(params.extra ?? {}),
   };
@@ -284,6 +496,7 @@ export const trackPurchase = (params: TrackPurchaseParams): boolean => {
     console.log("[Analytics] purchase event fired", {
       transactionId,
       value: roundedValue,
+      valueSource,
       itemsCount: normalizedItems.length,
       itemsValue,
       currency: payload.currency,
@@ -293,17 +506,22 @@ export const trackPurchase = (params: TrackPurchaseParams): boolean => {
   return true;
 };
 
-const BOOKING_FIRED_KEY_PREFIX = "ga_booking_fired_";
-
-export type TrackBookingParams = {
+// ── 8. reservation (бронь без онлайн-оплаты, путь «book») ────────────────
+export type TrackReservationParams = {
   purchaseId: string | number | null | undefined;
-  tripFrom: string;
-  tripTo: string;
+  locale?: Locale;
+  items?: EcommerceItem[];
+  /** Полная стоимость брони (цена билета × количество) ДО взвешивания. */
   value?: number | string | null;
   currency?: string | null;
+  tripFrom?: string;
+  tripTo?: string;
+  extra?: GtagParams;
 };
 
-export const trackBooking = (params: TrackBookingParams): boolean => {
+const RESERVATION_FIRED_KEY_PREFIX = "ga_reservation_fired_";
+
+export const trackReservation = (params: TrackReservationParams): boolean => {
   if (typeof window === "undefined") return false;
 
   const purchaseId =
@@ -312,43 +530,149 @@ export const trackBooking = (params: TrackBookingParams): boolean => {
       : "";
   if (!purchaseId) {
     if (isDev()) {
-      console.error("[Analytics] booking_success skipped: missing purchaseId");
+      console.error("[Analytics] reservation skipped: missing purchaseId");
     }
     return false;
   }
 
-  const firedKey = `${BOOKING_FIRED_KEY_PREFIX}${purchaseId}`;
+  const firedKey = `${RESERVATION_FIRED_KEY_PREFIX}${purchaseId}`;
   if (safeStorageGet(firedKey)) {
     if (isDev()) {
-      console.debug("[Analytics] booking_success skipped: already fired", {
+      console.debug("[Analytics] reservation skipped: already fired", {
         purchaseId,
       });
     }
     return false;
   }
 
+  const items = normalizeItems(params.items);
+  const baseValue = resolveValue(items, params.value);
+  // Взвешенная ценность: усредняет ожидаемую выручку по book-броням и не
+  // задваивает её с purchase (см. RESERVATION_WEIGHT).
+  const weightedValue = round2(baseValue * RESERVATION_WEIGHT);
+
   const payload: GtagParams = {
     transaction_id: purchaseId,
-    trip_from: params.tripFrom,
-    trip_to: params.tripTo,
-    currency: params.currency || FALLBACK_CURRENCY,
+    currency: params.currency || getCurrencyForLocale(params.locale),
+    value: weightedValue,
+    reservation_weight: RESERVATION_WEIGHT,
+    reservation_value_full: baseValue,
+    ...(items.length ? { items } : {}),
+    ...(params.tripFrom ? { trip_from: params.tripFrom } : {}),
+    ...(params.tripTo ? { trip_to: params.tripTo } : {}),
+    ...(params.extra ?? {}),
   };
 
-  const numericValue = toFiniteNumber(params.value);
-  if (numericValue !== null && numericValue > 0) {
-    payload.value = Number(numericValue.toFixed(2));
-  }
-
-  trackEvent("booking_success", payload);
+  trackEvent("reservation", payload);
   safeStorageSet(firedKey, String(Date.now()));
 
   if (isDev()) {
-    console.log("[Analytics] booking_success event fired", {
+    console.log("[Analytics] reservation event fired", {
       purchaseId,
-      value: payload.value,
+      value: weightedValue,
+      fullValue: baseValue,
+      weight: RESERVATION_WEIGHT,
       currency: payload.currency,
     });
   }
 
+  return true;
+};
+
+// ═══════════════════════ Contacts / leads ════════════════════════════════
+
+export type ContactMethod = "phone" | "email" | "telegram" | "viber" | "whatsapp";
+export type ContactSource =
+  | "topbar"
+  | "about_section"
+  | "parcel_section"
+  | "footer"
+  | "purchase_detail"
+  | (string & {});
+
+export type TrackContactParams = {
+  method: ContactMethod;
+  source: ContactSource;
+  /** Значение контакта (телефон / email / мессенджер) — необязательно. */
+  label?: string;
+  extra?: GtagParams;
+};
+
+/**
+ * Единое параметризованное событие контакта. Заменяет phone_click /
+ * messenger_click / email_click во всех компонентах.
+ */
+export const trackContact = (params: TrackContactParams) => {
+  trackEvent("contact", {
+    method: params.method,
+    source: params.source,
+    event_category: "conversion",
+    ...(params.label ? { event_label: params.label } : {}),
+    ...(params.extra ?? {}),
+  });
+};
+
+// ═══════════════════════ Content sections (Фаза 3) ════════════════════════
+
+export type SectionName =
+  | "schedule"
+  | "prices"
+  | "about"
+  | "parcel"
+  | "marshrut"
+  | (string & {});
+
+const VIEW_SECTION_FIRED_PREFIX = "ga_section_viewed_";
+
+/**
+ * view_section — одно параметризованное событие. Дедуп: один раз за сессию на
+ * секцию (sessionStorage). Возвращает true, если событие было отправлено.
+ */
+export const trackViewSection = (section: SectionName, extra?: GtagParams): boolean => {
+  if (typeof window === "undefined") return false;
+  const key = `${VIEW_SECTION_FIRED_PREFIX}${section}`;
+  try {
+    if (window.sessionStorage?.getItem(key)) return false;
+    window.sessionStorage?.setItem(key, "1");
+  } catch {
+    /* ignore storage errors — событие всё равно отправим */
+  }
+  trackEvent("view_section", { section, ...(extra ?? {}) });
+  return true;
+};
+
+// ═══════════════════════ Search intent (Фаза 3) ══════════════════════════
+
+export type TrackSearchIntentParams = {
+  locale?: Locale;
+  departure: string;
+  arrival: string;
+  /** Дошёл ли пользователь до шага выбора даты. */
+  reachedDateStep: boolean;
+  extra?: GtagParams;
+};
+
+const SEARCH_INTENT_FIRED_KEY = "ga_search_intent_fired";
+
+/**
+ * search_intent — намерение без результата: указаны departure и arrival, но
+ * клика «Поиск» не было. Слать один раз за сессию. Возвращает true, если
+ * событие было отправлено.
+ */
+export const trackSearchIntent = (params: TrackSearchIntentParams): boolean => {
+  if (typeof window === "undefined") return false;
+  try {
+    if (window.sessionStorage?.getItem(SEARCH_INTENT_FIRED_KEY)) return false;
+    window.sessionStorage?.setItem(SEARCH_INTENT_FIRED_KEY, "1");
+  } catch {
+    /* ignore storage errors — событие всё равно отправим */
+  }
+  trackEvent("search_intent", {
+    departure: params.departure,
+    arrival: params.arrival,
+    reached_date_step: params.reachedDateStep,
+    currency: getCurrencyForLocale(params.locale),
+    ...(params.extra ?? {}),
+  });
   return true;
 };

--- a/src/utils/useSectionView.ts
+++ b/src/utils/useSectionView.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { trackViewSection, type SectionName } from "@/lib/analytics";
+
+/**
+ * Отправляет view_section, когда секция становится видимой примерно на 50%.
+ * Дедуп — один раз за сессию на секцию (реализован внутри trackViewSection
+ * через sessionStorage), плюс локальный ref, чтобы не дёргать обсёрвер после
+ * первого срабатывания.
+ *
+ * Порог ~50% считается двумя способами (чтобы работать и для высоких секций,
+ * которые физически не могут занять 50% собственной площади в кадре):
+ *   • ≥50% площади самой секции в кадре, либо
+ *   • видимая часть секции покрывает ≥50% высоты вьюпорта.
+ *
+ * Возвращает ref, который нужно повесить на корневой элемент секции.
+ */
+export function useSectionView<T extends HTMLElement = HTMLElement>(
+  section: SectionName,
+) {
+  const ref = useRef<T | null>(null);
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const viewportHeight = entry.rootBounds?.height ?? 0;
+          const viewportCoverage =
+            viewportHeight > 0 ? entry.intersectionRect.height / viewportHeight : 0;
+          const visibleEnough =
+            entry.intersectionRatio >= 0.5 || viewportCoverage >= 0.5;
+          if (!visibleEnough) continue;
+          if (!firedRef.current) {
+            firedRef.current = true;
+            trackViewSection(section);
+          }
+          observer.disconnect();
+          break;
+        }
+      },
+      { threshold: [0, 0.25, 0.5, 0.75, 1] },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [section]);
+
+  return ref;
+}


### PR DESCRIPTION
## Summary

Comprehensive refactor of the GA4 analytics layer to implement a unified ecommerce funnel, derive currency from locale, and centralize all tracking through typed helpers. Removes hardcoded `FALLBACK_CURRENCY`, replaces generic `trackEvent` calls with semantic funnel functions, and adds new events (`view_item_list`, `search_intent`, `view_section`, `contact`).

## Key Changes

### Analytics Core (`src/lib/analytics.ts`)
- **Currency by locale:** Replaced `FALLBACK_CURRENCY = "UAH"` with `getCurrencyForLocale(locale?: Locale)` that maps `ru`/`ua`/`uk` → `UAH`, `en`/`bg` → `EUR`, defaults to `UAH`
- **Ecommerce funnel:** Implemented 8-step GA4 purchase funnel with typed helpers:
  1. `trackSearch` — search form submission
  2. `trackViewItemList` — tour list rendered (new)
  3. `trackSelectItem` — tour clicked
  4. `trackAddToCart` — seats selected (renamed from `view_item`)
  5. `trackBeginCheckout` — checkout screen opened
  6. `trackAddPaymentInfo` — payment initiated
  7. `trackPurchase` — payment confirmed (fixed value source)
  8. `trackReservation` — booking without online payment (renamed from `booking_success`, now weighted)
- **Item normalization:** Extracted `normalizeItems()`, `sumItemsValue()`, `resolveValue()` helpers to ensure consistent item structure and value calculation across funnel
- **Reservation weighting:** Added `RESERVATION_WEIGHT = 0.5` constant to weight booking events and prevent double-counting revenue
- **Purchase value fix:** Changed `purchase.value` source priority: per-ticket `pricing.price` (primary) → `ga_checkout_value` from sessionStorage (fallback) → `valueOverride` (last resort). Logs `valueSource` in dev mode to diagnose anomalies
- **New events:**
  - `trackContact(method, source)` — unified contact event (replaces `phone_click`, `messenger_click`, `email_click`)
  - `trackViewSection(section)` — section visibility with sessionStorage dedup
  - `trackSearchIntent(departure, arrival, reachedDateStep)` — search intent without submission (Фаза 3)
- **Type aliases:** Renamed `PurchaseEventItem` → `EcommerceItem` (kept alias for backward compat), added `Locale`, `ContactMethod`, `ContactSource`, `SectionName` types

### Components
- **SearchResults.tsx:** Replaced generic `trackEvent` calls with `trackSelectItem`, `trackAddToCart`, `trackAddPaymentInfo`, `trackReservation`; added `trackViewItemList` in useEffect; removed `begin_checkout` from action handler (moved to ContactsAndPaymentStep); stores `ga_checkout_value` in sessionStorage as funnel-consistent fallback
- **SearchForm.tsx:** Added `trackSearch` on form submit; implemented `trackSearchIntent` with 12s delay and sessionStorage dedup
- **ContactsAndPaymentStep.tsx:** Removed hardcoded `window.gtag("purchase_click")` call
- **Header.tsx, SiteFooter.tsx, AboutSection.tsx:** Replaced contact tracking with `trackContact(method, source)` calls
- **return/page.tsx:** Updated `trackPurchase` to use `getCurrencyForLocale(lang)` and per-ticket pricing from items
- **Schedule.tsx, About.tsx, ParcelSection.tsx, Routes.tsx:** Added `useSectionView` hook for `view_section` tracking

### New Utilities
- **useSectionView.ts:** Custom hook using IntersectionObserver (50% threshold) with sessionStorage dedup for `view_section` events

### Documentation
- **docs/analytics-events.md:** Comprehensive guide covering event map, CHANGELOG, purchase value fix, reservation weighting, and verification checklist

### Tests (`src/lib/analytics.test.ts`)

https://claude.ai/code/session_014pU3dAyBkfWr7grHTBj3JG