### PR TITLE
Update return-ticket discount note from 15% to 10%

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -145,7 +145,7 @@ export default function SearchResults({
 
   // Обратный билет с открытой датой (сценарий C): обратный рейс не выбирается,
   // бэкенд выпускает предоплаченный открытый обратный билет.
-  // Скидка −15% относится к обратному билету при покупке туда-обратно.
+  // Скидка −10% относится к обратному билету при покупке туда-обратно.
   const [openReturn, setOpenReturn] = useState(Boolean(openReturnInitial));
 
   // Итоговая сумма считается на бэкенде (quote), фронт её только отображает.
@@ -473,7 +473,7 @@ export default function SearchResults({
       let ticketNumbers = extractTicketNumbers(outRes.data);
       let finalPurchaseResponse = outRes.data;
 
-      // обратно (конкретная дата) — скидка −15% на обратный билет применяется бэкендом по is_return_leg
+      // обратно (конкретная дата) — скидка −10% на обратный билет применяется бэкендом по is_return_leg
       if (selectedReturnTour && !openReturn) {
         const retRes = await apiClient.post<PublicPurchaseResponse>(`/${endpoint}`, {
           ...basePayload,

--- a/src/components/search/searchDictionary.ts
+++ b/src/components/search/searchDictionary.ts
@@ -123,7 +123,7 @@ const dict: Record<Lang, Dict> = {
     openReturnHint:
       "Дату и место обратного рейса вы выберете позже в личном кабинете по QR-коду.",
     openReturnSummaryLabel: "Обратно (открытая дата)",
-    returnDiscountNote: "−15% на обратный билет при покупке туда-обратно",
+    returnDiscountNote: "−10% на обратный билет при покупке туда-обратно",
   },
   en: {
     noResults: "No trips found",
@@ -245,7 +245,7 @@ const dict: Record<Lang, Dict> = {
     openReturnHint:
       "You will choose the return date and seat later in your account via the QR code.",
     openReturnSummaryLabel: "Return (open date)",
-    returnDiscountNote: "15% off the return ticket with a round trip",
+    returnDiscountNote: "10% off the return ticket with a round trip",
   },
   bg: {
     noResults: "Няма намерени курсове",
@@ -368,7 +368,7 @@ const dict: Record<Lang, Dict> = {
     openReturnHint:
       "Датата и мястото за обратния курс ще изберете по-късно в профила си чрез QR кода.",
     openReturnSummaryLabel: "Обратно (отворена дата)",
-    returnDiscountNote: "−15% за обратния билет при двупосочно пътуване",
+    returnDiscountNote: "−10% за обратния билет при двупосочно пътуване",
   },
   ua: {
     noResults: "Рейси не знайдено",
@@ -491,7 +491,7 @@ const dict: Record<Lang, Dict> = {
     openReturnHint:
       "Дату та місце зворотного рейсу ви оберете пізніше в особистому кабінеті за QR-кодом.",
     openReturnSummaryLabel: "Назад (відкрита дата)",
-    returnDiscountNote: "−15% на зворотний квиток при купівлі туди й назад",
+    returnDiscountNote: "−10% на зворотний квиток при купівлі туди й назад",
   },
 };
 


### PR DESCRIPTION
Aligns the round-trip discount messaging with the backend, which now prices the return leg at -10%. Updates the returnDiscountNote in all four locales and the related code comments.


Claude-Session: https://claude.ai/code/session_01MTsRYojCQvchDEGNpiapcx